### PR TITLE
fix .zshrc

### DIFF
--- a/zsh/.zsh/.zshrc
+++ b/zsh/.zsh/.zshrc
@@ -48,3 +48,4 @@ fi
 # load .zshrc_*
 [ -f $ZDOTDIR/.zshrc_`uname` ] && . $ZDOTDIR/.zshrc_`uname`
 [ -f $ZDOTDIR/.zshrc_dircolors ] && . $ZDOTDIR/.zshrc_dircolors
+

--- a/zsh/.zsh/.zshrc_dircolors
+++ b/zsh/.zsh/.zshrc_dircolors
@@ -1,4 +1,4 @@
-if [[ -f ~/.dircolors && -x `which dircolors` ]]; then
-  eval `dircolors ~/.dircolors`
+if [[ -d ~/.dircolors && -x `which dircolors` ]]; then
+  eval `dircolors ~/.dircolors/dircolors.ansi-dark`
   zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
 fi


### PR DESCRIPTION
- added setting for dircolors
  - please clone the following schema in advance
    ```bash
    git clone https://github.com/seebi/dircolors-solarized.git ~/.dircolors
    ```