### PR TITLE
PATHを追加

### DIFF
--- a/zsh/.zsh/.zshrc_Linux
+++ b/zsh/.zsh/.zshrc_Linux
@@ -61,3 +61,6 @@ if [ -e "$HOME/.config/openbox/lxde-rc.xml" ]; then
   export LXDE_RC_PATH="$HOME/.config/openbox/lxde-rc.xml"
   alias vilxde-rc="vim $LXDE_RC_PATH"
 fi
+
+# Python user path
+export PATH=$PATH:$HOME/.local/bin


### PR DESCRIPTION
`sudo`をつけずに`pip install`したときにインストールされるローカル環境へのパスを追加