### PR TITLE
git configを追加

### DIFF
--- a/zsh/setup_tools/setting-git-config.sh
+++ b/zsh/setup_tools/setting-git-config.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 printf '\033[33m%s\033[m\n' "setting git config..."
-# Get arg
 
 # Get current config
 USERNAME=`git config --global user.name`

--- a/zsh/setup_tools/setting-git-config.sh
+++ b/zsh/setup_tools/setting-git-config.sh
@@ -8,6 +8,7 @@ EMAIL=`git config --global user.email`
 COLOR_UI=`git config --global color.ui`
 CORE_EDITOR=`git config --global core.editor`
 DELETE_MERGED_BRANCH=`git config --global alias.delete-merged-branch`
+GIT_VERSION=`git --version | sed -e 's/[^0-9]//g'`
 
 printf '\033[33m%s\033[m\n' "username"
 if [ "$USERNAME" == '' ]; then
@@ -31,4 +32,14 @@ fi
 printf '\033[33m%s\033[m\n' "alias"
 if [ "$DELETE_MERGED_BRANCH" == '' ]; then
 	git config --global alias.delete-merged-branch "!f () { git checkout $1; git branch --merged|egrep -v '\*|develop|master'|xargs git branch -d; };f"
+fi
+
+printf '\033[33m%s\033[m\n' "git pull config"
+if [ $GIT_VERSION -ge 2270 ]; then
+	PULL_REBASE=`git config --global pull.rebase`
+	if [ "$PULL_REBASE" == '' ]; then
+		git config --global pull.rebase false
+	fi
+else
+	printf '\033[33m%s\033[m\n' "git version lower 2.27.0"
 fi


### PR DESCRIPTION
`Git`のバージョンが`2.27.0`以上の時に`git pull`すると表示されるwarningへの対処

参考: [Git - warning: Pulling without specifying how to reconcile divergent branches is discouraged](https://qiita.com/black_iron/items/9e02c165d9c7e6f01db2)