### PR TITLE
WSL用の設定ファイルを追加

### DIFF
--- a/zsh/.zsh/.zshrc
+++ b/zsh/.zsh/.zshrc
@@ -54,3 +54,6 @@ fi
 # load .zshrc_*
 [ -f $ZDOTDIR/.zshrc_`uname` ] && . $ZDOTDIR/.zshrc_`uname`
 [ -f $ZDOTDIR/.zshrc_dircolors ] && . $ZDOTDIR/.zshrc_dircolors
+if [ -f /proc/sys/fs/binfmt_misc/WSLInterop ]; then
+	. $ZDOTDIR/.zshrc_wsl
+fi

--- a/zsh/.zsh/.zshrc_wsl
+++ b/zsh/.zsh/.zshrc_wsl
@@ -1,0 +1,1 @@
+alias open="/mnt/c/Windows/explorer.exe"


### PR DESCRIPTION
表題の通り

`WSL`環境かどうかの判定方法は以下

```bash
if [ -f /proc/sys/fs/binfmt_misc/WSLInterop ]; then
	. $ZDOTDIR/.zshrc_wsl
fi
```

参考：[[shell] WSL かどうかを判別する](https://moyapro.com/2018/03/21/detect-wsl/)