### PR TITLE
ROS設定ファイルの読み込み順番変更

### DIFF
--- a/zsh/.zsh/.zshrc_Linux
+++ b/zsh/.zsh/.zshrc_Linux
@@ -27,8 +27,8 @@ if [ -d "/opt/ros" ]; then
     cd ~/catkin_ws/src
   }
 
-  source /opt/ros/kinetic/setup.zsh
   source ~/catkin_ws/devel/setup.zsh
+  source /opt/ros/$ROS_DISTRO/setup.zsh
 fi
 
 # pyenv setting


### PR DESCRIPTION
最初に`~/catkin_ws/devel/setup.zsh`を読まないと`$ROS_DISTRO`変数がセットされないため修正