### PR TITLE
WSL用のpbcopyを追加

### DIFF
--- a/zsh/.zsh/.zshrc_wsl
+++ b/zsh/.zsh/.zshrc_wsl
@@ -1,1 +1,2 @@
 alias open="/mnt/c/Windows/explorer.exe"
+alias pbcopy="/mnt/c/windows/system32/clip.exe"


### PR DESCRIPTION
`WSL`では`Ubuntu`のように`xsel`を使ったコピーができなかった（ちゃんと設定すればできるかも）ので、同じ動作をする`Windows`標準の`clip.exe`を使用するよう変更

※`WSL`でWindowsのパスを除外しているのでエイリアスを貼っている

参考：[WSLでpbcopyを使う](https://qiita.com/meihei/items/d1c4399b99e4f22eabab)