### PR TITLE
サジェスト機能追加

### DIFF
--- a/zsh/.zsh/.zshrc
+++ b/zsh/.zsh/.zshrc
@@ -51,6 +51,9 @@ if [ ! "`which nodebrew`" = "" ]; then
 	export PATH=$HOME/.nodebrew/current/bin:$PATH
 fi
 
+# support command_not_found
+. /etc/zsh_command_not_found
+
 # load .zshrc_*
 [ -f $ZDOTDIR/.zshrc_`uname` ] && . $ZDOTDIR/.zshrc_`uname`
 [ -f $ZDOTDIR/.zshrc_dircolors ] && . $ZDOTDIR/.zshrc_dircolors


### PR DESCRIPTION
インストールされてないパッケージのコマンドを実行しようとした時、bashのようにインストール方法をサジェストするように修正

参考：[Zsh Package Suggestion](https://stackoverflow.com/questions/3316568/zsh-package-suggestion)