### PR TITLE
zsh_command_not_foundの読み込み場所修正

### DIFF
--- a/zsh/.zsh/.zshrc
+++ b/zsh/.zsh/.zshrc
@@ -51,9 +51,6 @@ if [ ! "`which nodebrew`" = "" ]; then
 	export PATH=$HOME/.nodebrew/current/bin:$PATH
 fi
 
-# support command_not_found
-. /etc/zsh_command_not_found
-
 # load .zshrc_*
 [ -f $ZDOTDIR/.zshrc_`uname` ] && . $ZDOTDIR/.zshrc_`uname`
 [ -f $ZDOTDIR/.zshrc_dircolors ] && . $ZDOTDIR/.zshrc_dircolors

--- a/zsh/.zsh/.zshrc_Linux
+++ b/zsh/.zsh/.zshrc_Linux
@@ -73,3 +73,6 @@ fi
 
 # Python user path
 export PATH=$PATH:$HOME/.local/bin
+
+# support command_not_found
+. /etc/zsh_command_not_found


### PR DESCRIPTION
`Linux`の場合に読み込むように修正