### PR TITLE
DISPLAY環境変数の設定を追加

### DIFF
--- a/zsh/.zsh/.zshrc_wsl
+++ b/zsh/.zsh/.zshrc_wsl
@@ -1,2 +1,4 @@
 alias open="/mnt/c/Windows/explorer.exe"
 alias pbcopy="/mnt/c/windows/system32/clip.exe"
+
+export DISPLAY=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}'):0.0


### PR DESCRIPTION
IPが変わっても対応できるように`/etc/resolv.conf`からIPを取得し設定している

参考：[WSL2におけるVcXsrvの設定](https://qiita.com/ryoi084/items/0dff11134592d0bb895c)