### PR TITLE
fix: add ~/.local/bin to PATH in zshrc

### DIFF
--- a/zsh/.zsh/.zshrc
+++ b/zsh/.zsh/.zshrc
@@ -1,3 +1,5 @@
+export PATH="$HOME/.local/bin:$PATH"
+
 setopt share_history
 setopt histignorealldups
 setopt auto_cd


### PR DESCRIPTION
## Summary
- `zsh/.zsh/.zshrc` の先頭で `~/.local/bin` を `PATH` に追加

## Why
- Claude Code のネイティブインストール (`~/.local/bin/claude`) や uv 関連バイナリが PATH に含まれておらず、Claude Code 起動時に `~/.local/bin is not in your PATH` の警告が表示されていた
- dotfiles の zsh 設定には `~/.local/bin` を追加する記述が無かった

## Impact
- 新しい zsh セッションで `~/.local/bin` 配下のコマンド (claude, uv, uvx など) が直接起動可能に
- 既存セッションへは影響なし（`source ~/.zshrc` で反映）

## Test
- `zsh -c 'source zsh/.zsh/.zshrc; echo $PATH'` で `/Users/iri/.local/bin` が PATH に含まれることを確認

## Notes
- uv 提供の `~/.local/bin/env` を source する方式もあるが、シンプルさを優先して直接 export を選択