### PR TITLE
feat: optimize skill layout (evensdk-dev split, visionos-dev references)

### DIFF
--- a/claude/.claude/skills/evensdk-dev/SKILL.md
+++ b/claude/.claude/skills/evensdk-dev/SKILL.md
@@ -1,24 +1,48 @@
 ---
 name: evensdk-dev
-description: Use when developing Even Realities G2 smart glasses apps (Even Hub plugins, BLE protocol, SDK, simulator/CLI). Covers SDK init, UI constraints (4-container limit, ASCII restrictions for listObject), known SDK hangs and timeout patterns, BLE packet structure, teleprompter protocol, and CORS/WebView constraints from iPhone.
+description: Use when developing Even Realities G2 smart glasses apps (Even Hub plugins via `@evenrealities/even_hub_sdk`, `@evenrealities/evenhub-simulator`, `@evenrealities/evenhub-cli`, Web app in iPhone WebView over BLE). Covers SDK init (`waitForEvenAppBridge` vs `EvenAppBridge.getInstance`), input events (`CLICK_EVENT`=0 / `DOUBLE_CLICK_EVENT`=3 / `FOREGROUND_ENTER_EVENT`=4 with `eventType === undefined` deserialization pitfall), UI constraints (4-container/page limit, 576×288 px, 4-bit grayscale, no CSS/Flexbox), known SDK hangs (`listObject.itemContainer.itemName` non-ASCII → no BLE ACK, `rebuildPageContainer` needs `Promise.race` timeout), simulator-vs-device divergence for listObject/CORS/`currentSelectItemIndex`, iPhone WebView CORS workarounds (Vite proxy / allorigins.win), and low-level BLE protocol (base UUID `00002760-08c2-11e1-9073-0e8ac72e{xxxx}`, service UUIDs `5401`/`5402`/`6402`, CRC-16/CCITT Init=0xFFFF Poly=0x1021, teleprompter service `0x06-20` with Mid-Stream Marker type=255, Protobuf payload).
 ---
 
-# Even Hub Pilot 開発ガイド
+# Even Hub / G2 開発ガイド
 
-## 概要
+Even Realities G2 スマートグラス向け Even Hub プラグイン開発のお作法と踏みやすい罠をまとめたもの。対象: Web アプリ (任意フレームワーク) + iPhone WebView + BLE 経由の G2 グラス。
 
-このプロジェクトは Even Realities G2 スマートグラスのアプリ（Even Hub プラグイン）を開発するためのワークスペースです。
+このファイルは索引。詳細は `references/*.md` を参照する。
 
-## 開発ドキュメント
+## 0. Quick lookup — 症状 → 原因候補
 
-開発は以下の公式・非公式ドキュメントを参照して行います。
+| 症状 | 原因候補 | 参照 |
+| :-- | :-- | :-- |
+| `rebuildPageContainer` が永遠に await されたまま返らない | BLE ACK が返ってこない → `Promise.race` でタイムアウト必須 | ui-constraints |
+| listObject を描画した瞬間にハング | `listObject.itemContainer.itemName` に非 ASCII 文字 (日本語など) → G2 firmware が ACK 返さない | ui-constraints |
+| `CLICK_EVENT` ハンドラが発火しない | `eventType === 0` が `undefined` にデシリアライズされている → `=== 0 \|\| === undefined` で判定 | sdk-usage |
+| シミュレータでは動くのに実機でだけハング | listObject 日本語 / CORS / `currentSelectItemIndex` の初回値差異 | ui-constraints |
+| Web アプリから外部 API 叩くと CORS エラー | iPhone WebView の制約 → Vite dev proxy or CORS proxy 経由 | ui-constraints |
+| `bridge` が `undefined` / メソッドが存在しない | `waitForEvenAppBridge` を await せずに `getInstance` 呼んでいる | sdk-usage |
+| レイアウトが崩れる / コンテナが 5 個目以降出ない | 1 ページあたり最大 4 コンテナ、ピクセル座標での絶対配置のみ | ui-constraints |
+| 画像が意図と違う見た目になる | 全画像は 4-bit グレースケール (グリーン 16 階調) に変換される | ui-constraints |
+| 自前 BLE 実装で ACK が来ない | CRC-16/CCITT (Init=0xFFFF, Poly=0x1021) の計算先 / リトルエンディアン | ble-protocol |
+| テレプロンプタで Content Pages が欠落 | Mid-Stream Marker (`0x06-20`, type=255) を挟み忘れ | ble-protocol |
 
-- **Unofficial "What's Possible" Guide**: https://github.com/nickustinov/even-g2-notes/blob/main/G2.md
-  - アーキテクチャ、SDK API、UI システム、イベント処理など、開発に必要な技術情報が網羅されている
-- **G2 BLE Protocol（リバースエンジニアリング）**: https://github.com/i-soxi/even-g2-protocol
-  - BLE パケット構造、サービス ID、認証ハンドシェイク、テレプロンプタープロトコル等の低レベル仕様
+## 1. アーキテクチャ
 
-## NPM パッケージ
+```
+[Your server] <--HTTPS--> [iPhone WebView] <--BLE--> [G2 Glasses]
+```
+
+- Web アプリ＋プロキシモデル
+- iPhone がミドルウェアとして G2 と BLE 通信を中継する
+- グラスはディスプレイ＆入力ペリフェラル — 独立した処理能力は持たない
+
+**ハードウェア仕様**:
+
+- ディスプレイ: デュアルマイクロ LED (グリーン)、**576 × 288 px / 眼**
+- 色深度: **4-bit グレースケール** (グリーン 16 階調)
+- 接続: BLE 5.x (最大 ~28 m)
+- 入力: R1 リング、テンプルタッチジェスチャー
+- センサー: マイク、装着検出
+
+## 2. NPM パッケージ
 
 ```bash
 npm install @evenrealities/evenhub-simulator   # シミュレーター
@@ -26,209 +50,15 @@ npm install @evenrealities/evenhub-cli         # CLI ツール
 npm install @evenrealities/even_hub_sdk        # SDK コア
 ```
 
-- **Simulator**: https://www.npmjs.com/package/@evenrealities/evenhub-simulator
-- **CLI**: https://www.npmjs.com/package/@evenrealities/evenhub-cli
-- **SDK**: https://www.npmjs.com/package/@evenrealities/even_hub_sdk
+## 3. 詳細 references
 
-## アーキテクチャ
+- **`references/sdk-usage.md`** — SDK 初期化 (`waitForEvenAppBridge` / `EvenAppBridge.getInstance`)、入力イベント一覧、`CLICK_EVENT === undefined` ワークアラウンド、開発フロー、参考ドキュメント
+- **`references/ui-constraints.md`** — UI システム (4 コンテナ / 絶対座標 / 固定幅フォント / 4-bit 画像)、listObject 非 ASCII ハング対策 + `toAsciiSafe`、`rebuildPageContainer` の `Promise.race` タイムアウト、シミュレータ/実機差異、WebView CORS
+- **`references/ble-protocol.md`** — BLE サービス UUID、パケット構造、CRC-16/CCITT、サービス ID 一覧、デュアルチャネル、テレプロンプタープロトコル (`0x06-20`)、Protobuf ペイロード、リバース進捗
 
-```
-[Your server] <--HTTPS--> [iPhone WebView] <--BLE--> [G2 Glasses]
-```
+## 4. 公式・コミュニティ
 
-- Web アプリ＋プロキシモデル
-- iPhone がミドルウェアとして G2 グラスと BLE 通信を中継する
-- グラスはディスプレイ＆入力ペリフェラルとして機能し、独立した処理能力は持たない
-
-## ハードウェア仕様
-
-- **ディスプレイ**: デュアルマイクロ LED（グリーン）、576×288 px / 眼
-- **色深度**: 4-bit グレースケール（グリーン 16 階調）
-- **接続**: BLE 5.x（最大約 28m）
-- **入力**: R1 リング、テンプルタッチジェスチャー
-- **センサー**: マイク、装着検出
-
-## UI システム
-
-- 1 ページあたり最大 **4 コンテナ**
-- コンテナはピクセル座標で絶対配置（CSS/Flexbox は使用不可）
-- コンテナ種別: **Text / List / Image**
-- フォント制御不可、固定幅フォントのみ
-- 全画像は 4-bit グレースケールに変換される
-
-## SDK 初期化
-
-```js
-// 推奨（非同期）
-const bridge = await waitForEvenAppBridge();
-
-// 同期（初期化後のみ）
-const bridge = EvenAppBridge.getInstance();
-```
-
-## 入力イベント
-
-| イベント | 値 | 内容 |
-|---------|---|------|
-| `CLICK_EVENT` | 0 | リング/テンプルタップ |
-| `DOUBLE_CLICK_EVENT` | 3 | ダブルタップ |
-| `FOREGROUND_ENTER_EVENT` | 4 | アプリ前面 |
-| `FOREGROUND_EXIT_EVENT` | 5 | アプリ背面 |
-| `ABNORMAL_EXIT_EVENT` | 6 | 切断 |
-
-**注意**: `CLICK_EVENT`（値 0）はデシリアライズ時に `undefined` になる場合があるため、`eventType === 0 || eventType === undefined` で判定する。
-
-## 開発フロー
-
-1. SDK をインポートした Web アプリを構築（任意のフレームワーク可）
-2. 開発中: localhost で起動 → Even App が WebView で URL を読み込む
-3. 本番: 任意のホストにデプロイ → Even App からそのURLを読み込む
-4. シミュレーターで動作確認（`even-dev` 環境）
-
-## 既知の挙動・注意事項
-
-### listObject と textObject の文字セット制約
-
-- `listObject.itemContainer.itemName`（リスト項目）に **ASCII 範囲外の文字（日本語など）を含めると G2 ファームウェアが BLE ACK を返さず、SDK の Promise が無限にハングする**
-- `textObject.content`（テキストコンテナ）は日本語をそのまま扱える
-- 対策: listObject に渡す文字列は事前に非 ASCII 文字を除去する
-
-```typescript
-function toAsciiSafe(text: string): string {
-  return text.replace(/[^\x00-\x7F]/g, ' ').replace(/\s+/g, ' ').trim();
-}
-```
-
-### rebuildPageContainer のハング対策
-
-BLE ACK が返らない場合に `rebuildPageContainer` が永遠に await されることがある。
-`Promise.race` でタイムアウトを設けて確実にエラーハンドリングできるようにする。
-
-```typescript
-const timeout = new Promise<never>((_, reject) =>
-  setTimeout(() => reject(new Error('timeout')), 15_000)
-);
-return await Promise.race([bridge.rebuildPageContainer(config), timeout]);
-```
-
-### シミュレーターと実機の差異
-
-| 項目 | シミュレーター | 実機 |
-|------|-------------|------|
-| 日本語 listObject | 問題なし（モック処理） | ハング |
-| `currentSelectItemIndex` 初回値 | `undefined` になることがある | 正常 |
-| CORS | 制限なし | WebView の制約あり（プロキシ必要） |
-
-### iPhone WebView からの外部 HTTP リクエスト
-
-iPhone の Even App WebView から RSS 等の外部 URL を直接 fetch すると CORS でブロックされる。
-Vite の dev server プロキシか、外部 CORS プロキシ（allorigins.win、corsproxy.io 等）を経由する。
-
-## G2 BLE プロトコル（リバースエンジニアリング）
-
-SDK の下位レイヤーで動作する BLE プロトコルの仕様。直接 BLE 通信を行う場合や、SDK の挙動を理解するために参照する。
-
-### BLE サービス UUID
-
-```
-ベース UUID: 00002760-08c2-11e1-9073-0e8ac72e{xxxx}
-```
-
-| UUID サフィックス | 用途 |
-|------------------|------|
-| `0000` | メインサービス |
-| `5401` | Write（コマンド送信: Phone → Glasses） |
-| `5402` | Notify（レスポンス: Glasses → Phone） |
-| `6402` | ディスプレイレンダリング |
-
-- **MTU**: 512 bytes
-- **接続パラメータ**: Interval 7.5-30ms, Supervision Timeout 2000ms
-- **ペアリング**: 標準 BLE ペアリング不要、アプリレベルの 7 パケットハンドシェイクで認証
-
-### パケット構造
-
-```
-[AA] [Type] [Seq] [Len] [PktTot] [PktSer] [SvcHi] [SvcLo] [Payload...] [CRC_Lo] [CRC_Hi]
- [0]   [1]   [2]   [3]    [4]      [5]      [6]      [7]      [8:N-2]     [N-1]    [N]
-```
-
-- **Type**: `0x21` = コマンド（Phone→Glasses）、`0x12` = レスポンス（Glasses→Phone）
-- **Len**: ペイロード長 + 2（CRC 含む）
-- **CRC**: CRC-16/CCITT (Init=0xFFFF, Poly=0x1021), ペイロードのみ対象, リトルエンディアン
-- **マルチパケット**: MTU 超過時は PktTot/PktSer で分割（Seq ID は全パケット共通）
-
-### サービス ID 一覧
-
-| サービス ID | 名前 | 説明 |
-|------------|------|------|
-| `0x80-00` | Auth Control | セッション管理・同期 |
-| `0x80-20` | Auth Data | 認証（ペイロード付き） |
-| `0x04-20` | Display Wake | ディスプレイ起動 |
-| `0x06-20` | Teleprompter | テキスト表示・スクリプト |
-| `0x07-20` | Dashboard | ウィジェット（カレンダー等） |
-| `0x09-00` | Device Info | バージョン・ファームウェア |
-| `0x0B-20` | Conversate | 音声トランスクリプション |
-| `0x0C-20` | Tasks | ToDo リスト |
-| `0x0D-00` | Configuration | デバイス設定 |
-| `0x0E-20` | Display Config | ディスプレイパラメータ |
-| `0x20-20` | Commit | 変更確定 |
-
-### デュアルチャネルアーキテクチャ
-
-- **Content Channel (0x5401)**: 表示データの送信（テキスト、構造化データ）
-- **Rendering Channel (0x6402)**: 表示方法の制御（座標、スタイリング）
-
-### テレプロンプタープロトコル (0x06-20)
-
-スクロール可能なテキスト表示。メッセージシーケンス:
-
-1. 認証パケット（7 パケット）
-2. Display Config (`0x0E-20`, type=2)
-3. Teleprompter Init (`0x06-20`, type=1) — スクリプト選択・モード設定
-4. Content Pages 0-9 (`0x06-20`, type=3)
-5. Mid-Stream Marker (`0x06-20`, type=255) — 必須マーカー
-6. Content Pages 10-11 (`0x06-20`, type=3)
-7. Sync Trigger (`0x80-00`, type=14)
-8. 残りの Content Pages (`0x06-20`, type=3)
-
-**メッセージタイプ**:
-
-| Type | 用途 |
-|------|------|
-| 1 | Init（スクリプト選択・表示モード設定） |
-| 2 | Script List（デバイス上のスクリプト一覧） |
-| 3 | Content Page（テキストコンテンツ送信） |
-| 4 | Content Complete（送信完了通知） |
-| 255 | Mid-Stream Marker（ストリーミング中の必須マーカー） |
-
-**表示仕様**: 1 行 ~25 文字、1 ページ 10 行、可視領域 ~7 行
-
-**スクロールモード**: `0x00` = 手動（"M" インジケータ）、`0x01` = AI モード（アニメーション）
-
-### Protobuf ペイロード
-
-ペイロードは protobuf エンコーディング。主要メッセージ定義:
-
-- `TeleprompterMessage`: type(1), msg_id(2), init/list/content/complete/marker
-- `DisplayConfig`: type(1), msg_id(2), settings(4) — リージョン定義含む
-- `ConversateTranscript`: text(1), is_final(2)
-- `NotificationData`: app_id(1), count(2) — メタデータのみ、テキストなし
-
-詳細な .proto 定義: https://github.com/i-soxi/even-g2-protocol/tree/main/proto
-
-### リバースエンジニアリング状況
-
-| 機能 | ステータス |
-|------|-----------|
-| BLE 接続 | 動作確認済み |
-| 認証 | 動作確認済み（7 パケットハンドシェイク） |
-| テレプロンプター | 動作確認済み |
-| カレンダーウィジェット | 動作確認済み |
-| 通知 | 部分的（メタデータのみ） |
-| Even AI | 調査中 |
-| ナビゲーション | 調査中 |
-
-## コミュニティ
-
+- **Unofficial "What's Possible" Guide**: https://github.com/nickustinov/even-g2-notes/blob/main/G2.md
+- **G2 BLE Protocol (リバースエンジニアリング)**: https://github.com/i-soxi/even-g2-protocol
 - **Discord**: https://discord.gg/Y4jHMCU4sv
 - **問い合わせ**: david.yu@evenrealities.com

--- a/claude/.claude/skills/evensdk-dev/references/ble-protocol.md
+++ b/claude/.claude/skills/evensdk-dev/references/ble-protocol.md
@@ -1,0 +1,108 @@
+# G2 BLE プロトコル（リバースエンジニアリング）
+
+SDK の下位レイヤーで動作する BLE プロトコルの仕様。直接 BLE 通信を行う場合や、SDK の挙動を理解するために参照する。出典: https://github.com/i-soxi/even-g2-protocol
+
+## BLE サービス UUID
+
+```
+ベース UUID: 00002760-08c2-11e1-9073-0e8ac72e{xxxx}
+```
+
+| UUID サフィックス | 用途 |
+|------------------|------|
+| `0000` | メインサービス |
+| `5401` | Write（コマンド送信: Phone → Glasses） |
+| `5402` | Notify（レスポンス: Glasses → Phone） |
+| `6402` | ディスプレイレンダリング |
+
+- **MTU**: 512 bytes
+- **接続パラメータ**: Interval 7.5-30ms, Supervision Timeout 2000ms
+- **ペアリング**: 標準 BLE ペアリング不要、アプリレベルの 7 パケットハンドシェイクで認証
+
+## パケット構造
+
+```
+[AA] [Type] [Seq] [Len] [PktTot] [PktSer] [SvcHi] [SvcLo] [Payload...] [CRC_Lo] [CRC_Hi]
+ [0]   [1]   [2]   [3]    [4]      [5]      [6]      [7]      [8:N-2]     [N-1]    [N]
+```
+
+- **Type**: `0x21` = コマンド（Phone→Glasses）、`0x12` = レスポンス（Glasses→Phone）
+- **Len**: ペイロード長 + 2（CRC 含む）
+- **CRC**: CRC-16/CCITT (Init=`0xFFFF`, Poly=`0x1021`), ペイロードのみ対象, リトルエンディアン
+- **マルチパケット**: MTU 超過時は `PktTot` / `PktSer` で分割（`Seq` ID は全パケット共通）
+
+## サービス ID 一覧
+
+| サービス ID | 名前 | 説明 |
+|------------|------|------|
+| `0x80-00` | Auth Control | セッション管理・同期 |
+| `0x80-20` | Auth Data | 認証（ペイロード付き） |
+| `0x04-20` | Display Wake | ディスプレイ起動 |
+| `0x06-20` | Teleprompter | テキスト表示・スクリプト |
+| `0x07-20` | Dashboard | ウィジェット（カレンダー等） |
+| `0x09-00` | Device Info | バージョン・ファームウェア |
+| `0x0B-20` | Conversate | 音声トランスクリプション |
+| `0x0C-20` | Tasks | ToDo リスト |
+| `0x0D-00` | Configuration | デバイス設定 |
+| `0x0E-20` | Display Config | ディスプレイパラメータ |
+| `0x20-20` | Commit | 変更確定 |
+
+## デュアルチャネルアーキテクチャ
+
+- **Content Channel (`0x5401`)**: 表示データの送信（テキスト、構造化データ）
+- **Rendering Channel (`0x6402`)**: 表示方法の制御（座標、スタイリング）
+
+## テレプロンプタープロトコル (`0x06-20`)
+
+スクロール可能なテキスト表示。メッセージシーケンス:
+
+1. 認証パケット（7 パケット）
+2. Display Config (`0x0E-20`, type=2)
+3. Teleprompter Init (`0x06-20`, type=1) — スクリプト選択・モード設定
+4. Content Pages 0-9 (`0x06-20`, type=3)
+5. Mid-Stream Marker (`0x06-20`, type=255) — 必須マーカー
+6. Content Pages 10-11 (`0x06-20`, type=3)
+7. Sync Trigger (`0x80-00`, type=14)
+8. 残りの Content Pages (`0x06-20`, type=3)
+
+**メッセージタイプ**:
+
+| Type | 用途 |
+|------|------|
+| 1 | Init（スクリプト選択・表示モード設定） |
+| 2 | Script List（デバイス上のスクリプト一覧） |
+| 3 | Content Page（テキストコンテンツ送信） |
+| 4 | Content Complete（送信完了通知） |
+| 255 | Mid-Stream Marker（ストリーミング中の必須マーカー） |
+
+**表示仕様**: 1 行 ~25 文字、1 ページ 10 行、可視領域 ~7 行
+
+**スクロールモード**: `0x00` = 手動（"M" インジケータ）、`0x01` = AI モード（アニメーション）
+
+## Protobuf ペイロード
+
+ペイロードは protobuf エンコーディング。主要メッセージ定義:
+
+- `TeleprompterMessage`: type(1), msg_id(2), init/list/content/complete/marker
+- `DisplayConfig`: type(1), msg_id(2), settings(4) — リージョン定義含む
+- `ConversateTranscript`: text(1), is_final(2)
+- `NotificationData`: app_id(1), count(2) — メタデータのみ、テキストなし
+
+詳細な `.proto` 定義: https://github.com/i-soxi/even-g2-protocol/tree/main/proto
+
+## リバースエンジニアリング状況
+
+| 機能 | ステータス |
+|------|-----------|
+| BLE 接続 | 動作確認済み |
+| 認証 | 動作確認済み（7 パケットハンドシェイク） |
+| テレプロンプター | 動作確認済み |
+| カレンダーウィジェット | 動作確認済み |
+| 通知 | 部分的（メタデータのみ） |
+| Even AI | 調査中 |
+| ナビゲーション | 調査中 |
+
+## コミュニティ・問い合わせ
+
+- **Discord**: https://discord.gg/Y4jHMCU4sv
+- **問い合わせ**: david.yu@evenrealities.com

--- a/claude/.claude/skills/evensdk-dev/references/sdk-usage.md
+++ b/claude/.claude/skills/evensdk-dev/references/sdk-usage.md
@@ -1,0 +1,64 @@
+# SDK 利用
+
+`@evenrealities/even_hub_sdk` を使った Even Hub プラグイン開発の基本。
+
+## SDK 初期化
+
+```js
+// 推奨（非同期）— bridge 準備完了まで待つ
+const bridge = await waitForEvenAppBridge();
+
+// 同期（初期化後のみ安全）
+const bridge = EvenAppBridge.getInstance();
+```
+
+開発初期は `waitForEvenAppBridge` を使うのが安全。`getInstance` は一度 bridge が立ち上がっていることが確定している箇所でのみ使う。
+
+## 入力イベント
+
+| イベント | 値 | 内容 |
+|---------|---|------|
+| `CLICK_EVENT` | 0 | リング/テンプルタップ |
+| `DOUBLE_CLICK_EVENT` | 3 | ダブルタップ |
+| `FOREGROUND_ENTER_EVENT` | 4 | アプリ前面 |
+| `FOREGROUND_EXIT_EVENT` | 5 | アプリ背面 |
+| `ABNORMAL_EXIT_EVENT` | 6 | 切断 |
+
+**注意**: `CLICK_EVENT`（値 0）はデシリアライズ時に `undefined` になる場合があるため、`eventType === 0 || eventType === undefined` で判定する。
+
+```js
+bridge.on('input', (e) => {
+  const t = e.eventType;
+  if (t === 0 || t === undefined) {
+    handleClick();
+  }
+});
+```
+
+## NPM パッケージ
+
+```bash
+npm install @evenrealities/evenhub-simulator   # シミュレーター
+npm install @evenrealities/evenhub-cli         # CLI ツール
+npm install @evenrealities/even_hub_sdk        # SDK コア
+```
+
+- **Simulator**: https://www.npmjs.com/package/@evenrealities/evenhub-simulator
+- **CLI**: https://www.npmjs.com/package/@evenrealities/evenhub-cli
+- **SDK**: https://www.npmjs.com/package/@evenrealities/even_hub_sdk
+
+## 開発フロー
+
+1. SDK をインポートした Web アプリを構築（任意のフレームワーク可）
+2. 開発中: localhost で起動 → Even App が WebView で URL を読み込む
+3. 本番: 任意のホストにデプロイ → Even App からその URL を読み込む
+4. シミュレーター（`even-dev` 環境）で動作確認
+
+実機での検証は `ui-constraints.md` の「シミュレーターと実機の差異」表を必ず参照すること — 実機でしか出ないハングが存在する。
+
+## 参考ドキュメント
+
+- **Unofficial "What's Possible" Guide**: https://github.com/nickustinov/even-g2-notes/blob/main/G2.md
+  — アーキテクチャ、SDK API、UI システム、イベント処理など開発に必要な情報が網羅されている
+- **G2 BLE Protocol (リバースエンジニアリング)**: https://github.com/i-soxi/even-g2-protocol
+  — BLE パケット構造、サービス ID、認証ハンドシェイク、テレプロンプタープロトコル等の低レベル仕様

--- a/claude/.claude/skills/evensdk-dev/references/ui-constraints.md
+++ b/claude/.claude/skills/evensdk-dev/references/ui-constraints.md
@@ -1,0 +1,61 @@
+# UI 制約とハマりどころ
+
+G2 の UI はファームウェア側で強く制約されていて、普通の Web UI のつもりで書くと高確率でハマる。既知の地雷とその対策。
+
+## UI システムの基本制約
+
+- 1 ページあたり最大 **4 コンテナ**
+- コンテナはピクセル座標で**絶対配置**（CSS/Flexbox は使用不可）
+- コンテナ種別: **Text / List / Image**
+- フォント制御不可、固定幅フォントのみ
+- 全画像は **4-bit グレースケール**（グリーン 16 階調）に変換される
+- 解像度は **576 × 288 px / 眼**
+
+レイアウトはピクセル単位で設計する前提。「ブラウザでいい感じに並べる」発想は捨てる。
+
+## listObject と textObject の文字セット制約
+
+- `listObject.itemContainer.itemName`（リスト項目）に **ASCII 範囲外の文字（日本語など）を含めると G2 ファームウェアが BLE ACK を返さず、SDK の Promise が無限にハングする**
+- `textObject.content`（テキストコンテナ）は日本語をそのまま扱える
+- 対策: listObject に渡す文字列は事前に非 ASCII 文字を除去する
+
+```typescript
+function toAsciiSafe(text: string): string {
+  return text.replace(/[^\x00-\x7F]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+```
+
+症状だけ見ると「SDK が壊れている」ように見えるので、原因特定までに時間を溶かしやすい。ユーザー入力をそのまま listObject に流さない。
+
+## rebuildPageContainer のハング対策
+
+BLE ACK が返らない場合に `rebuildPageContainer` が永遠に await されることがある。
+`Promise.race` でタイムアウトを設けて確実にエラーハンドリングできるようにする。
+
+```typescript
+const timeout = new Promise<never>((_, reject) =>
+  setTimeout(() => reject(new Error('timeout')), 15_000)
+);
+return await Promise.race([bridge.rebuildPageContainer(config), timeout]);
+```
+
+15 秒は実機の ACK 往復の余裕を見た目安。短すぎると正常ケースで誤タイムアウトする。
+
+## シミュレーターと実機の差異
+
+| 項目 | シミュレーター | 実機 |
+|------|-------------|------|
+| 日本語 listObject | 問題なし（モック処理） | ハング |
+| `currentSelectItemIndex` 初回値 | `undefined` になることがある | 正常 |
+| CORS | 制限なし | WebView の制約あり（プロキシ必要） |
+
+シミュレーターで「動いた」が実機で即ハマるのがよくあるパターン。特に listObject と CORS は**必ず実機で一度通す**。
+
+## iPhone WebView からの外部 HTTP リクエスト
+
+iPhone の Even App WebView から RSS 等の外部 URL を直接 fetch すると CORS でブロックされる。対処:
+
+- 開発中: Vite の dev server プロキシ
+- 本番: 外部 CORS プロキシ（allorigins.win、corsproxy.io など）を経由
+
+アプリから直接外部 API を叩けない前提で設計する。自前サーバー経由のほうがトークン等も扱いやすい。

--- a/claude/.claude/skills/visionos-dev/SKILL.md
+++ b/claude/.claude/skills/visionos-dev/SKILL.md
@@ -1,56 +1,52 @@
 ---
 name: visionos-dev
-description: Use when developing visionOS apps for Apple Vision Pro (Swift/SwiftUI, ARKit, RealityKit, hand/world/plane/scene tracking, RealityView, Enterprise APIs/entitlements, XcodeGen). Covers Swift 6 strict concurrency for ARKit (single ARKitSession.run([providers]) pattern), DeviceAnchor.originFromAnchorTransform, HandSkeleton 27 joints, system gesture suppression (.upperLimbVisibility/.allowsHitTesting), Enterprise license debugging (XPC sandbox Code 4099, EnterpriseLicenseDetails.shared, EnterpriseEntitlement allCases), Full Space requirement, and xcodebuild quirks (DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer).
+description: Use when developing visionOS apps for Apple Vision Pro (Swift/SwiftUI, ARKit, RealityKit, hand/world/plane/scene tracking, RealityView, Reality Composer Pro, attachments, gestures, HoverEffectComponent, ImmersiveSpace lifecycle, WorldAnchor persistence, Enterprise APIs/entitlements, XcodeGen, xcrun devicectl, Instruments). Covers Swift 6 strict concurrency for ARKit (single ARKitSession.run([providers]) pattern), DeviceAnchor.originFromAnchorTransform, HandSkeleton 27 joints, CollisionComponent+InputTargetComponent pairing for entity taps, RealityView attachments 2-closure form, openImmersiveSpace/dismissImmersiveSpace + scenePhase, WorldTrackingProvider.addAnchor persistence, Enterprise license debugging (XPC sandbox Code 4099 step-by-step recipe, EnterpriseLicenseDetails.shared, EnterpriseEntitlement allCases), Full Space requirement, simulator-vs-device capability matrix, and xcodebuild quirks (DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer).
 ---
 
 # visionOS 開発ガイド
 
-Apple Vision Pro / visionOS アプリ開発のお作法と踏みやすい罠をまとめたもの。Swift / SwiftUI / ARKit / RealityKit / Vision Pro Enterprise API を対象とする。
+Apple Vision Pro / visionOS アプリ開発のお作法と踏みやすい罠をまとめたもの。対象: Swift / SwiftUI / ARKit / RealityKit / Vision Pro Enterprise API。
 
-## 1. 動作環境とツール
+このファイルは索引。詳細は `references/*.md` を参照する。
+
+## 0. Quick lookup — 症状 → 原因候補
+
+| 症状 | 原因候補 | 参照 |
+| :-- | :-- | :-- |
+| `anchorUpdates` が一切届かない | Full Space でない / 権限文言未記載 / `isSupported` false / `session.run()` 未呼出 | arkit-sensors |
+| `session.run()` を 2 回呼んだ後クラッシュ | 全 provider は **1 回の** `run([providers])` にまとめる | arkit-sensors |
+| Entity をタップしても反応しない | `CollisionComponent` と `InputTargetComponent` **両方**が必要 | realitykit-ui |
+| `.upperLimbVisibility(.hidden)` がビルドエラー | `RealityView { ... }` の**閉じカッコの外**に置く | realitykit-ui |
+| Attachment が画面に出ない | `attachments.entity(for: id)` を `content.add()` し忘れ | realitykit-ui |
+| バックグラウンドから復帰後にトラッキング止まる | ARKitSession は OS に停止される → scenePhase `.active` で `run()` 再呼出 | immersive-space |
+| ImmersiveSpace を閉じても再度開けない | `@State` 同期ミス + `.onChange` で dismiss 反映 | immersive-space |
+| `EnterpriseLicenseDetails` が常に `.notFound` | Bundle ID/Team ID 不一致 or `.license` が bundle に入っていない | enterprise |
+| `NSCocoaErrorDomain Code 4099` (XPC) | entitlement キー宣言忘れ / `.entitlements` が project に紐付いてない | enterprise |
+| シミュレータで ARKit 全部 false | 仕様 — ARKit provider は**実機必須** | build-and-test |
+| `xcodebuild` が sudo を要求 | `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer` を指定 | build-and-test |
+| ROS 2 との Python 連携で pytest が ament プラグイン読み込み | `PYTHONPATH=""` で `uv run` (iri-dotfiles の `uv` wrapper が自動で) | (参考) |
+
+## 1. 動作環境
 
 - **visionOS**: 26.0+
 - **Swift**: 6.0 (strict concurrency 前提)
-- **Xcode**: 26.0
-- **XcodeGen**: `project.yml` からの Xcode プロジェクト生成 (本ガイドの全プロジェクトで採用)
-- **uv**: Python 連携 (avp-stream など) の依存解決
+- **Xcode**: 26.0 (Command Line Tools だけでは不足)
+- **XcodeGen**: `project.yml` から `.xcodeproj` を生成 — 本ガイドの全プロジェクトで前提
+- **uv**: Python 連携 (avp-stream など) のパッケージ管理
 
-## 2. プロジェクトセットアップ (XcodeGen)
+## 2. シーン構成
 
-```yaml
-# project.yml の最小例
-name: MyApp
-options:
-  bundleIdPrefix: com.example
-  deploymentTarget:
-    visionOS: "26.0"
-  xcodeVersion: "26.0"
-  createIntermediateGroups: true
+| SwiftUI Scene | 用途 | ARKit provider |
+| :-- | :-- | :-- |
+| `WindowGroup` | 2D ウィンドウ | ✗ anchor 来ない |
+| `Volume` (`.windowStyle(.volumetric)`) | 3D ウィンドウ | ✗ anchor 来ない |
+| `ImmersiveSpace` | Full Space / 空間没入 | ✓ 動く |
 
-targets:
-  MyApp:
-    type: application
-    platform: visionOS
-    sources:
-      - path: MyApp
-    info:
-      path: MyApp/Info.plist
-      properties:
-        NSWorldSensingUsageDescription: "..."
-        NSHandsTrackingUsageDescription: "..."
-        UIApplicationSceneManifest:
-          UIApplicationPreferredDefaultSceneSessionRole: UIWindowSceneSessionRoleApplication
-          UIApplicationSupportsMultipleScenes: true
-          UISceneConfigurations: {}
-        UILaunchScreen: {}
-    settings:
-      base:
-        SWIFT_VERSION: "6.0"
-        VISIONOS_DEPLOYMENT_TARGET: "26.0"
-        ENABLE_PREVIEWS: YES
-```
+**鉄則**: ARKit のデータプロバイダ (HandTracking / WorldTracking / PlaneDetection / SceneReconstruction) は **ImmersiveSpace (Full Space) でしか動かない**。Shared Space (WindowGroup / Volume) では認可が通っても anchor が 1 つも来ない。
 
-### Info.plist プライバシーキー
+`Info.plist` の `UIApplicationSceneManifest` で複数シーン宣言。詳細は `immersive-space.md`。
+
+## 3. Info.plist プライバシーキー
 
 | キー | 用途 |
 | :-- | :-- |
@@ -59,212 +55,20 @@ targets:
 | `NSPhotoLibraryUsageDescription` | 写真ライブラリ |
 | `NSMainCameraUsageDescription` | Enterprise 限定: メインカメラアクセス |
 
-権限キーを忘れると **エラーは出ずデータも来ない** ので発見が遅れる。Plist と `requestAuthorization` 両方が必須。
+権限キーを忘れると**エラーは出ずデータも来ない**ので発見が遅れる。Plist と `requestAuthorization` の**両方**が必須。
 
-## 3. ビルドコマンド
+## 4. 詳細 references
 
-```bash
-xcodegen generate                                            # project.yml → .xcodeproj
-DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
-  xcodebuild -scheme MyApp -destination 'generic/platform=visionOS' build
-```
+- **`references/arkit-sensors.md`** — `ARKitSession` 設計、4 プロバイダ (World/Hand/Plane/Scene)、Swift 6 strict concurrency、メモリ・Hz 計測、座標変換
+- **`references/realitykit-ui.md`** — `RealityView` の make/update パターン、Entity 事前割り当て、システムジェスチャ制御、Input/Gesture、Attachments 2-クロージャ、Reality Composer Pro 連携
+- **`references/immersive-space.md`** — `openImmersiveSpace`/`dismissImmersiveSpace`、`scenePhase` による session 停止/再開、`WorldAnchor` 永続化
+- **`references/enterprise.md`** — `EnterpriseLicenseDetails`、entitlement 設定、**XPC Code 4099 step-by-step デバッグレシピ**
+- **`references/build-and-test.md`** — `xcodegen` / `xcodebuild` / 署名切り分け、**Sim vs 実機 対応表**、`xcrun devicectl`、Instruments (visionOS)、ユニットテスト戦略
 
-- **Command Line Tools のみでは不足** — `DEVELOPER_DIR` で full Xcode を指定しないと `xcodebuild` が sudo パスワードを要求する/フレームワークが見つからない
-- `project.yml` を編集したら必ず `xcodegen generate` を再実行
+## 5. 公式リファレンス
 
-## 4. シーン構成
-
-- `WindowGroup` — 通常の 2D ウィンドウ
-- `ImmersiveSpace` — Full Space (空間没入)
-- `UIApplicationSceneManifest` で複数シーン宣言
-
-> **重要**: ARKit のデータプロバイダ (HandTracking / WorldTracking 等) は **Full Space (ImmersiveSpace) でしか動かない**。Shared Space (WindowGroup / Volume) では認可が通っても anchor が一切来ない。
-
-## 5. ARKit ベストプラクティス
-
-公式パターンと実プロジェクト (SensorScope) で実証済み。
-
-```swift
-import ARKit
-
-actor SensorManager {
-    private let session = ARKitSession()
-    private let worldSensor = WorldTrackingSensor()
-    private let handSensor  = HandTrackingSensor()
-
-    func start(...) async throws {
-        // (1) 一括認可
-        let statuses = await session.requestAuthorization(
-            for: [.worldSensing, .handTracking]
-        )
-        for (type, status) in statuses where status != .allowed {
-            throw SensorError.authorizationDenied("\(type)")
-        }
-
-        // (2) 全プロバイダを 1 回の run() にまとめる
-        var providers: [any DataProvider] = []
-        if WorldTrackingSensor.isSupported { providers.append(worldSensor.provider) }
-        if HandTrackingSensor.isSupported  { providers.append(handSensor.provider) }
-        try await session.run(providers)
-
-        // (3) anchorUpdates を並列処理
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask { try await self.worldSensor.process(...) }
-            group.addTask { try await self.handSensor.process(...) }
-            try await group.waitForAll()
-        }
-    }
-
-    func stop() {
-        session.stop()   // 明示的に停止 (キャンセル任せにしない)
-    }
-}
-```
-
-### 守るべきルール
-
-- **`ARKitSession` を強参照**で保持 (release されると provider も死ぬ)
-- **`session.run()` は 1 回だけ**、配列 `[any DataProvider]` で全 provider をまとめる (2 回呼ぶと壊れる)
-- 各 Provider の **static `isSupported`** を必ず確認 (デバイス互換)
-- 終了時は **明示的に `session.stop()`**
-- センサーごとに `actor` 化、`nonisolated let provider` で provider への並行アクセスを許可
-
-## 6. トラッキングプロバイダ
-
-### WorldTrackingProvider — 頭部姿勢
-
-```swift
-let deviceAnchor = worldTrackingProvider.queryDeviceAnchor(
-    atTimestamp: CACurrentMediaTime()
-)
-let transform: simd_float4x4 = deviceAnchor?.originFromAnchorTransform ?? .init()
-// → 頭部の 4×4 ワールド変換行列 (位置 + 回転)
-```
-
-### HandTrackingProvider — 27 関節
-
-```swift
-let (left, right) = handTrackingProvider.latestAnchors
-
-for hand in [left, right] {
-    guard let hand,
-          let joint = hand.handSkeleton?.joint(.thumbTip) else { continue }
-    let world = hand.originFromAnchorTransform * joint.anchorFromJointTransform
-    // ↑ 関節のワールド座標
-}
-
-// 全関節を網羅したい場合
-for jointName in HandSkeleton.JointName.allCases {
-    // 27 関節 (wrist, forearmWrist, forearmArm, 5 指 × 5 関節)
-}
-```
-
-- `handAnchor.chirality` が `.left` / `.right` を返す
-- すべての関節は `.wrist` を root とする階層
-
-### PlaneDetectionProvider / SceneReconstructionProvider
-
-- 同じ `ARKitSession` に渡して並走可
-- `.isSupported` チェック必須 (Mac/Sim 等で false になる)
-- **`MeshAnchor` / `PlaneAnchor` をそのまま蓄積するとメモリ上限なく増え続ける** — 必要なのが count なら count のみ保持
-
-## 7. RealityKit パターン
-
-```swift
-RealityView { content in
-    // make: 初期エンティティ追加
-    let root = Entity()
-    for _ in 0..<27 {
-        let sphere = ModelEntity(mesh: .generateSphere(radius: 0.006), ...)
-        root.addChild(sphere)   // 事前割り当て
-    }
-    content.add(root)
-} update: { content in
-    // update: 毎フレーム transform のみ更新
-    // (子 entity を毎フレーム作り直さない)
-}
-.upperLimbVisibility(.hidden)         // ← RealityView の閉じカッコの外!
-.allowsHitTesting(false)              // 内側に書くとビルドエラー
-```
-
-- **Entity は事前割り当て**して毎フレーム `transform` だけ更新するのが基本パターン (生成コスト回避)
-- インタラクション entity は `CollisionComponent(shapes:)` + `InputTargetComponent()` の両方が必要
-
-## 8. システムジェスチャ制御
-
-ハンドトラッキング中にシステムの look+pinch 描画と当たり判定を抑制したいとき:
-
-```swift
-.upperLimbVisibility(.hidden)     // システムの手描画 (上肢) を非表示
-.allowsHitTesting(false)          // look+pinch 入力を無効化
-```
-
-`.upperLimbVisibility(_:)` の値: `.visible` / `.hidden` / `.automatic`
-
-## 9. Swift 6 strict concurrency
-
-- `@MainActor` で UI / 共有状態 (`@Observable` モデル)
-- `actor` でセンサー / I/O
-- `nonisolated let provider` で provider プロパティを並行アクセス可能に
-- データ受け渡しは `Sendable` 型で
-- 並列タスクは `withThrowingTaskGroup(of:)`
-
-## 10. メモリ・パフォーマンスの罠
-
-- `MeshAnchor` / `PlaneAnchor` 自体を `[Anchor]` に蓄積しない (count や軽量フィールドだけ抽出)
-- Hz 計測は **1 秒ローリング窓** (タイムスタンプ配列の先頭から 1 秒以上前を捨てる)
-
-## 11. Vision Pro Enterprise API
-
-```swift
-import VisionEntitlementServices
-
-let details = EnterpriseLicenseDetails.shared
-
-// ステータス
-switch details.licenseStatus {
-case .valid:         ...
-case .notFound:      ...   // Bundle ID / Team ID 不一致 / .license 欠落
-case .invalidFormat: ...
-case .expired:       ...
-case .notAuthorized: ...   // entitlement キーが空 / 申請未承認
-@unknown default:    ...   // 必須
-}
-
-// 期限 (non-optional Date — 未初期化時は 1970-01-01 epoch)
-let expires: Date = details.expirationTimestamp
-
-// 全 entitlement を列挙
-for entitlement in EnterpriseLicenseDetails.EnterpriseEntitlement.allCases {
-    let approved: Bool = details.isApproved(for: entitlement)
-}
-```
-
-### 設定とハマりどころ
-
-| 項目 | 内容 |
-| :-- | :-- |
-| `.license` ファイル登録 | XcodeGen `project.yml` の `sources` に `path: Enterprise.license, buildPhase: resources` |
-| Enum はネスト型 | `EnterpriseLicenseDetails.EnterpriseEntitlement.allCases` (top-level ではない) |
-| 空 `.entitlements` | `com.apple.enterprise.licensing` への XPC 接続が sandbox にブロック → `NSCocoaErrorDomain Code 4099` |
-| 必要な entitlement キー | Apple 承認済みキーを最低 1 つ宣言 (例: `com.apple.developer.arkit.main-camera-access.allow`) |
-| シミュレータ | **Enterprise API は全無効** — 実機必須 |
-| 一致要件 | Bundle ID / Team ID が Apple 申請時と完全一致していないと `.notFound` |
-| API 表記の差 | 公式ドキュメントに古い名前 (`Feature` / `expirationDate?` 等) が残っている。SDK の `.swiftinterface` を直読するのが確実 |
-
-## 12. 回転・座標変換
-
-- `simd_quatf` (クォータニオン) → Euler (yaw / pitch / roll) 変換は手動実装が必要 (visionOS 標準には無い)
-- `simd_float4x4` の分解:
-  - position: `transform.columns.3.xyz`
-  - right axis: `transform.columns.0.xyz`
-  - up axis: `transform.columns.1.xyz`
-  - forward axis: `-transform.columns.2.xyz` (右手系の慣習)
-
-## 13. デバッグ参考リンク
-
-- [Apple Developer Documentation](https://developer.apple.com/documentation/visionos)
+- [Apple Developer Documentation — visionOS](https://developer.apple.com/documentation/visionos)
 - WWDC23: Meet ARKit for spatial computing (session 10082)
 - WWDC24: Create enhanced spatial computing experiences with ARKit (session 10100)
 - WWDC24: Introducing enterprise APIs for visionOS (session 10139)
-- 困ったら **`.swiftinterface` 直読** (`<Xcode>/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/.../<Framework>.framework/Modules/<Framework>.swiftmodule/*.swiftinterface`)
+- 困ったら **`.swiftinterface` 直読**: `<Xcode>/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/.../<Framework>.framework/Modules/<Framework>.swiftmodule/*.swiftinterface`

--- a/claude/.claude/skills/visionos-dev/references/arkit-sensors.md
+++ b/claude/.claude/skills/visionos-dev/references/arkit-sensors.md
@@ -1,0 +1,176 @@
+# ARKit / センサー
+
+`ARKitSession` と各データプロバイダの扱い方。Swift 6 strict concurrency 前提。
+
+## ARKitSession の基本パターン
+
+公式パターン。実プロジェクト (SensorScope) で実証済み。
+
+```swift
+import ARKit
+
+actor SensorManager {
+    private let session = ARKitSession()
+    private let worldSensor = WorldTrackingSensor()
+    private let handSensor  = HandTrackingSensor()
+
+    func start() async throws {
+        // (1) 認可を一括要求
+        let statuses = await session.requestAuthorization(
+            for: [.worldSensing, .handTracking]
+        )
+        for (type, status) in statuses where status != .allowed {
+            throw SensorError.authorizationDenied("\(type)")
+        }
+
+        // (2) 全プロバイダを 1 回の run() にまとめる
+        var providers: [any DataProvider] = []
+        if WorldTrackingProvider.isSupported { providers.append(worldSensor.provider) }
+        if HandTrackingProvider.isSupported  { providers.append(handSensor.provider) }
+        try await session.run(providers)
+
+        // (3) anchorUpdates を並列処理
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await self.worldSensor.process() }
+            group.addTask { try await self.handSensor.process() }
+            try await group.waitForAll()
+        }
+    }
+
+    func stop() {
+        session.stop()   // 明示停止 (cancel 任せにしない)
+    }
+}
+```
+
+## 守るべき 5 つのルール
+
+1. **`ARKitSession` を強参照で保持** — release されると provider も死ぬ
+2. **`session.run()` は 1 回だけ** — `[any DataProvider]` に全 provider を入れて渡す (2 回呼ぶと壊れる)
+3. 各 provider の **static `isSupported` を必ず確認** — Mac / Sim / 未対応デバイスで false
+4. 終了時は **明示的に `session.stop()`** — task cancel 任せにしない
+5. センサーごとに `actor` 化、`nonisolated let provider` で provider 自体への並行アクセスを許可
+
+## 4 つのプロバイダ
+
+### WorldTrackingProvider — 頭部姿勢
+
+```swift
+let deviceAnchor = worldTrackingProvider.queryDeviceAnchor(
+    atTimestamp: CACurrentMediaTime()
+)
+let transform: simd_float4x4 = deviceAnchor?.originFromAnchorTransform ?? .init()
+// → 頭部の 4×4 ワールド変換行列 (位置 + 回転)
+```
+
+- `anchorUpdates` ではなく **`queryDeviceAnchor(atTimestamp:)` でポーリング**するのが基本
+- `WorldAnchor` の永続化もこの provider で扱う (`immersive-space.md` 参照)
+
+### HandTrackingProvider — 27 関節
+
+```swift
+let (left, right) = handTrackingProvider.latestAnchors
+
+for hand in [left, right] {
+    guard let hand,
+          let joint = hand.handSkeleton?.joint(.thumbTip) else { continue }
+    // 関節のワールド座標 = handAnchor × jointLocal
+    let world = hand.originFromAnchorTransform * joint.anchorFromJointTransform
+}
+
+// 全関節を網羅したい場合
+for jointName in HandSkeleton.JointName.allCases {
+    // 27 関節: wrist, forearmWrist, forearmArm, 5 指 × 5 関節 (mcp/pip/dip/tip + knuckle)
+}
+```
+
+- `handAnchor.chirality` が `.left` / `.right`
+- すべての関節は `.wrist` を root とする階層
+- `HandSkeleton.JointName.allCases` が 27 要素 — enum なので forEach で網羅可
+
+### PlaneDetectionProvider — 平面検出
+
+```swift
+let provider = PlaneDetectionProvider(alignments: [.horizontal, .vertical])
+for await update in provider.anchorUpdates {
+    switch update.event {
+    case .added, .updated:   /* update.anchor: PlaneAnchor */
+    case .removed:           /* 削除 */
+    }
+}
+```
+
+- `PlaneAnchor.classification` で床/壁/天井/机などを判別
+- `PlaneAnchor.geometry.meshVertices` で実際の形状
+
+### SceneReconstructionProvider — 空間メッシュ
+
+```swift
+let provider = SceneReconstructionProvider(modes: [.classification])
+for await update in provider.anchorUpdates {
+    let mesh: MeshAnchor = update.anchor
+    // mesh.geometry.meshFaces / .meshVertices / .meshClassifications
+}
+```
+
+## メモリ・パフォーマンスの罠
+
+- **`MeshAnchor` / `PlaneAnchor` 自体を配列に蓄積しない** — 各 anchor は数 MB、メモリ上限無く増え続けて OOM。必要な情報 (count、軽量フィールド) だけ抽出して離す
+- **毎フレーム全 anchor を走査しない** — `.added` / `.updated` / `.removed` の差分で状態を更新し続ける
+- **Hz 計測は 1 秒ローリング窓** でやる:
+
+```swift
+actor HzCounter {
+    private var timestamps: [CFAbsoluteTime] = []
+    func tick() -> Double {
+        let now = CFAbsoluteTimeGetCurrent()
+        timestamps.append(now)
+        timestamps.removeAll { $0 < now - 1.0 }
+        return Double(timestamps.count)
+    }
+}
+```
+
+## Swift 6 strict concurrency
+
+- `@MainActor`: UI / `@Observable` モデル / SwiftUI View 内の共有状態
+- `actor`: センサーマネージャ / I/O / バッファ
+- `nonisolated let provider`: `ARKitSession` から参照される provider プロパティ — `actor` の外からも参照されるので isolate しない
+- `Sendable`: actor 境界を越えるデータはすべて `Sendable` 準拠
+- 並列: `withThrowingTaskGroup(of:)` で provider ごとに `group.addTask`
+
+```swift
+actor HandSensor {
+    let provider = HandTrackingProvider()   // ❌ var だと Sendable 警告
+    // ↓ 正解
+    nonisolated let provider = HandTrackingProvider()
+}
+```
+
+## 座標変換
+
+`visionOS` は右手系。`simd_float4x4` と `simd_quatf` を行き来する。
+
+```swift
+// simd_float4x4 の分解
+let position = transform.columns.3.xyz                    // 位置
+let right    = transform.columns.0.xyz                    // 右軸
+let up       = transform.columns.1.xyz                    // 上軸
+let forward  = -transform.columns.2.xyz                   // 前方軸 (右手系慣習で反転)
+
+// simd_quatf → Euler (yaw/pitch/roll) は標準 API に無い → 自前実装
+extension simd_quatf {
+    var eulerYXZ: SIMD3<Float> {
+        let q = self.vector
+        let yaw   = atan2(2*(q.w*q.y + q.x*q.z), 1 - 2*(q.y*q.y + q.x*q.x))
+        let pitch = asin(max(-1, min(1, 2*(q.w*q.x - q.z*q.y))))
+        let roll  = atan2(2*(q.w*q.z + q.y*q.x), 1 - 2*(q.x*q.x + q.z*q.z))
+        return SIMD3(pitch, yaw, roll)
+    }
+}
+
+// simd_float4 → SIMD3 のショートカット
+extension SIMD4 where Scalar == Float {
+    var xyz: SIMD3<Float> { SIMD3(x, y, z) }
+}
+```

--- a/claude/.claude/skills/visionos-dev/references/build-and-test.md
+++ b/claude/.claude/skills/visionos-dev/references/build-and-test.md
@@ -1,0 +1,263 @@
+# ビルド / 署名 / テスト / プロファイリング
+
+XcodeGen + `xcodebuild` の回し方、シミュレータと実機の挙動差、`xcrun devicectl`、Instruments、ユニットテストの設計。
+
+## プロジェクト生成 — XcodeGen
+
+```yaml
+# project.yml 最小例
+name: MyApp
+options:
+  bundleIdPrefix: com.example
+  deploymentTarget:
+    visionOS: "26.0"
+  xcodeVersion: "26.0"
+  createIntermediateGroups: true
+
+targets:
+  MyApp:
+    type: application
+    platform: visionOS
+    sources:
+      - path: MyApp
+      - path: Enterprise.license
+        buildPhase: resources        # Enterprise 時のみ
+    info:
+      path: MyApp/Info.plist
+      properties:
+        NSWorldSensingUsageDescription: "..."
+        NSHandsTrackingUsageDescription: "..."
+        UIApplicationSceneManifest:
+          UIApplicationPreferredDefaultSceneSessionRole: UIWindowSceneSessionRoleApplication
+          UIApplicationSupportsMultipleScenes: true
+          UISceneConfigurations: {}
+        UILaunchScreen: {}
+    entitlements:
+      path: MyApp/MyApp.entitlements
+    settings:
+      base:
+        SWIFT_VERSION: "6.0"
+        VISIONOS_DEPLOYMENT_TARGET: "26.0"
+        ENABLE_PREVIEWS: YES
+```
+
+- `project.yml` を変更したら必ず `xcodegen generate` を再実行
+- `.xcodeproj` を手で編集しない (上書きされる)
+
+## xcodebuild の罠
+
+### DEVELOPER_DIR を明示する
+
+Command Line Tools だけだと `xcodebuild` が sudo パスワードを要求する/フレームワーク未検出になる:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  xcodebuild -scheme MyApp -destination 'generic/platform=visionOS' build
+```
+
+alias にしておくと楽:
+
+```bash
+alias xcb='DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild'
+```
+
+### destination の違い
+
+| destination | 用途 |
+| :-- | :-- |
+| `generic/platform=visionOS` | 実機汎用 (ipa 生成) |
+| `generic/platform=visionOS Simulator` | Sim 汎用 |
+| `platform=visionOS Simulator,name=Apple Vision Pro` | 特定 Sim で test |
+| `id=<UDID>` | 特定実機 |
+
+### archive → export
+
+```bash
+# archive
+xcodebuild -scheme MyApp \
+  -destination 'generic/platform=visionOS' \
+  -archivePath build/MyApp.xcarchive \
+  archive
+
+# ipa export
+xcodebuild -exportArchive \
+  -archivePath build/MyApp.xcarchive \
+  -exportPath build/ \
+  -exportOptionsPlist ExportOptions.plist
+```
+
+### 署名エラーの切り分け
+
+| エラー | 原因 |
+| :-- | :-- |
+| `No profiles for 'com.example.MyApp' were found` | Bundle ID に対する provisioning profile が Team に無い |
+| `requires a provisioning profile with the ... feature` | entitlement に対応する capability が App ID に未登録 |
+| `Code Signing Error: entitlements file MyApp.entitlements specifies ... but the profile does not contain them` | profile を再ダウンロード (Xcode > Preferences > Accounts > Download Manual Profiles) |
+
+## Sim vs 実機 対応表
+
+visionOS Simulator はカメラ系・Enterprise 系がすべて動かない。早い段階で実機検証を組み込む。
+
+| 機能 | Sim | 実機 |
+| :-- | :-: | :-: |
+| WorldTracking | × | ✓ |
+| HandTracking | × | ✓ |
+| PlaneDetection | × | ✓ |
+| SceneReconstruction | × | ✓ |
+| MainCameraAccess (Enterprise) | × | ✓ |
+| WorldAnchor 永続化 | × | ✓ |
+| RealityKit レンダ | ✓ | ✓ |
+| RealityView Attachments | ✓ | ✓ |
+| SpatialTapGesture / DragGesture | ✓ | ✓ |
+| ImmersiveSpace の開閉 | ✓ | ✓ |
+| EnterpriseLicenseDetails | × (常に `.notFound`) | ✓ |
+
+Sim では `ARKitProvider.isSupported` が **false** を返す。ガードがないと認可要求すら飛ばず沈黙するので、`isSupported` false 時は UI で「実機必須」を表示するのが親切。
+
+## xcrun devicectl — 実機制御
+
+Vision Pro への install / launch / ログ取得。
+
+```bash
+# 接続デバイス一覧
+xcrun devicectl list devices
+
+# アプリインストール
+xcrun devicectl device install app \
+  --device <DEVICE_ID> \
+  /path/to/MyApp.app
+
+# 起動
+xcrun devicectl device process launch \
+  --device <DEVICE_ID> \
+  --environment-variables "DEBUG=1" \
+  com.example.MyApp
+
+# プロセス一覧
+xcrun devicectl device info processes --device <DEVICE_ID>
+
+# ロック状態/バッテリ
+xcrun devicectl device info lockState --device <DEVICE_ID>
+```
+
+ログは Console.app で該当デバイスを選択して subsystem/process でフィルタするのが最速。
+
+## Instruments (visionOS)
+
+Xcode > Open Developer Tool > Instruments で **"visionOS" テンプレートグループ**を使う。
+
+### FPS / フレーム時間
+
+- "Metal System Trace" でフレーム時間を可視化
+- "Points of Interest" に `os_signpost` を仕込むと actor メソッド境界が可視化される:
+
+```swift
+import os
+
+private let signposter = OSSignposter(subsystem: "MyApp", category: "sensor")
+
+actor SensorManager {
+    func process() async {
+        let state = signposter.beginInterval("process")
+        defer { signposter.endInterval("process", state) }
+        // ...
+    }
+}
+```
+
+### ARKit / RealityKit
+
+- "ARKit" template で anchor イベント頻度、authorization 状態を確認
+- "RealityKit Trace" で Entity 更新回数、レンダリングコストを測定
+- Hand/World/Plane/Scene の Hz が期待値 (1-90 Hz) 未満なら overload
+
+### CPU Profiler の読み方
+
+- actor は独自スレッドではなく cooperative thread pool で走る
+- メソッド名に `[Actor].<func>` が出るので、各 actor のホットスポットを特定できる
+- `@MainActor` に重い処理が載っていないかが最優先チェックポイント
+
+## ユニットテスト戦略
+
+ARKitSession は実機必須なので、テスタブルにするには抽象化が必要。
+
+### ARKitSession を protocol で抽象化
+
+```swift
+protocol SensorSession: Sendable {
+    func requestAuthorization(for: [ARKitSession.AuthorizationType]) async
+        -> [ARKitSession.AuthorizationType: ARKitSession.AuthorizationStatus]
+    func run(_ providers: [any DataProvider]) async throws
+    func stop()
+}
+
+extension ARKitSession: SensorSession {}
+
+actor SensorManager {
+    private let session: SensorSession
+    init(session: SensorSession = ARKitSession()) { self.session = session }
+    // ...
+}
+
+// テスト用
+final class MockSensorSession: SensorSession { /* ... */ }
+```
+
+### 計算関数を純粋関数として切り出す
+
+Hand joint → world transform の計算は `ARKitSession` 不要。
+
+```swift
+// 純粋関数 — ユニットテスト可能
+func worldTransform(
+    handOrigin: simd_float4x4,
+    jointLocal: simd_float4x4
+) -> simd_float4x4 {
+    handOrigin * jointLocal
+}
+
+// テスト
+func testWorldTransform_identity() {
+    let result = worldTransform(handOrigin: .identity, jointLocal: .identity)
+    XCTAssertEqual(result, matrix_identity_float4x4)
+}
+```
+
+### Integration test は実機
+
+Full Space に依存するロジック (actual ARKit anchor / Enterprise license / MainCamera) は**実機でしかテストできない**。テスト目標:
+
+- ユニットテスト (Sim で高速): 計算関数、状態機械、SwiftUI view の state 遷移
+- Integration テスト (実機手動): 権限フロー、anchor 受信、永続化復元、Enterprise status
+
+### プレビュー (`#Preview`) でできること
+
+- SwiftUI view のレイアウト確認
+- RealityView の Entity 初期配置確認
+- ARKit 系は動かない — 常に静的モックで値を流す
+
+## 参考コマンド (チートシート)
+
+```bash
+# プロジェクト再生成
+xcodegen generate
+
+# Debug build
+xcb -scheme MyApp -destination 'generic/platform=visionOS' build
+
+# Test (Sim)
+xcb -scheme MyApp -destination 'platform=visionOS Simulator,name=Apple Vision Pro' test
+
+# Archive + export
+xcb -scheme MyApp -destination 'generic/platform=visionOS' \
+    -archivePath build/MyApp.xcarchive archive
+xcb -exportArchive -archivePath build/MyApp.xcarchive \
+    -exportPath build/ -exportOptionsPlist ExportOptions.plist
+
+# 実機 install + launch
+xcrun devicectl device install app --device <ID> build/MyApp.app
+xcrun devicectl device process launch --device <ID> com.example.MyApp
+
+# entitlement 埋め込み確認
+codesign -d --entitlements :- build/MyApp.app
+```

--- a/claude/.claude/skills/visionos-dev/references/enterprise.md
+++ b/claude/.claude/skills/visionos-dev/references/enterprise.md
@@ -1,0 +1,155 @@
+# Vision Pro Enterprise API
+
+Apple から事業者向けに発行される `.license` と entitlement を使う API 群。Main Camera Access / Object Tracking Parameter Adjustment などが該当。**実機必須、Sim 不可**。
+
+## EnterpriseLicenseDetails の使い方
+
+```swift
+import VisionEntitlementServices
+
+let details = EnterpriseLicenseDetails.shared
+
+// ステータス
+switch details.licenseStatus {
+case .valid:         /* OK */
+case .notFound:      /* Bundle ID / Team ID 不一致 or .license ファイル欠落 */
+case .invalidFormat: /* ファイル破損 */
+case .expired:       /* 期限切れ */
+case .notAuthorized: /* entitlement キー空 or Apple 未承認 */
+@unknown default:    /* Swift 6 必須 */
+}
+
+// 期限 (non-optional Date — 未初期化時は 1970-01-01 epoch)
+let expires: Date = details.expirationTimestamp
+
+// 全 entitlement を列挙
+for entitlement in EnterpriseLicenseDetails.EnterpriseEntitlement.allCases {
+    let approved: Bool = details.isApproved(for: entitlement)
+}
+```
+
+### 罠
+
+- **enum は top-level ではなくネスト型**: `EnterpriseLicenseDetails.EnterpriseEntitlement.allCases`
+- **API 表記は公式ドキュメントが古いことがある** — SDK の `.swiftinterface` を直読するのが確実
+- `expirationTimestamp` は **non-optional** — 未設定時は epoch を返す。期限判定は `details.expirationTimestamp > Date()` と書く
+
+## XPC Code 4099 デバッグレシピ
+
+`NSCocoaErrorDomain Code 4099` (`com.apple.enterprise.licensing` への XPC 接続失敗) の切り分け手順。
+
+### Step 1. entitlement キーが宣言されているか
+
+Xcode > Signing & Capabilities で **Apple 承認済みキー**が最低 1 つ入っているか確認:
+
+```
+com.apple.developer.arkit.main-camera-access.allow
+com.apple.developer.arkit.object-tracking-parameter-adjustment.allow
+com.apple.developer.arkit.world-sensing.allow
+(その他 Apple から通知された Team 専用キー)
+```
+
+### Step 2. `.entitlements` ファイルがプロジェクトに紐付いているか
+
+```bash
+xcodebuild -showBuildSettings -scheme MyApp | grep CODE_SIGN_ENTITLEMENTS
+```
+
+空文字なら `project.yml` に以下を追加:
+
+```yaml
+targets:
+  MyApp:
+    entitlements:
+      path: MyApp/MyApp.entitlements
+      properties:
+        com.apple.developer.arkit.main-camera-access.allow: true
+```
+
+### Step 3. ビルド後の .app に entitlement が埋め込まれているか
+
+```bash
+codesign -d --entitlements :- /path/to/MyApp.app
+# → <plist> の中に宣言したキーが並ぶこと
+```
+
+空 dict or 該当キー不在なら Step 2 に戻る。
+
+### Step 4. `.license` が Bundle に同梱されているか
+
+```yaml
+targets:
+  MyApp:
+    sources:
+      - path: Enterprise.license
+        buildPhase: resources    # ← 必須
+```
+
+ビルド後:
+
+```bash
+ls /path/to/MyApp.app/Enterprise.license   # 存在を確認
+```
+
+### Step 5. Bundle ID / Team ID の完全一致
+
+`.license` ファイルの中身 (plist または JSON 互換) を開き:
+
+- `bundle-id` がターゲットの CFBundleIdentifier と**大文字小文字含め完全一致**
+- `team-id` が Xcode の Signing > Team と一致
+
+一方でも違うと `.notFound` 返却。
+
+### Step 6. Apple 申請済み entitlement が Team に紐付いているか
+
+App Store Connect > Certificates, Identifiers & Profiles > Identifiers > App ID > 該当キーがチェックされているか。承認前だと空 entitlement 扱い → `.notAuthorized`。
+
+### Step 7. 実機で動いているか
+
+**Enterprise API は Simulator で全無効**。`licenseStatus` が常に `.notFound` を返す。実機にインストールして `EnterpriseLicenseDetails.shared.licenseStatus` を確認。
+
+### Step 8. Console.app で XPC ログ確認
+
+Console.app でデバイスを選択 → フィルタ `subsystem:com.apple.VisionEntitlementServices` で詳細ログ。sandbox 拒否の行があれば Step 1-3 に戻る。
+
+## ステータス別の第一手
+
+| licenseStatus | 最初に疑う場所 |
+| :-- | :-- |
+| `.valid` | OK |
+| `.notFound` | `.license` 同梱 (Step 4) / Bundle ID 一致 (Step 5) |
+| `.invalidFormat` | `.license` ファイル破損 — Apple に再発行依頼 |
+| `.expired` | `expirationTimestamp` 確認 → Apple 再発行 |
+| `.notAuthorized` | entitlement キー宣言 (Step 1-3) / Apple 承認 (Step 6) |
+
+## 代表的な Enterprise entitlement
+
+Apple から通知されるキー。有効化には申請と承認が必要:
+
+- `com.apple.developer.arkit.main-camera-access.allow` — Main Camera への直接アクセス
+- `com.apple.developer.arkit.object-tracking-parameter-adjustment.allow` — ObjectTracking のパラメータ調整
+- `com.apple.developer.arkit.world-sensing.allow` — Enhanced world sensing
+- (その他 Team 専用キー)
+
+承認済みキー一覧は Apple からの連絡メール or App Store Connect で確認。
+
+## `.swiftinterface` 直読
+
+公式ドキュメントが古い場合、SDK の `.swiftinterface` が最も確実:
+
+```
+/Applications/Xcode.app/Contents/Developer/Platforms/XROS.platform/Developer/SDKs/XROS.sdk/System/Library/Frameworks/VisionEntitlementServices.framework/Modules/VisionEntitlementServices.swiftmodule/arm64-apple-xros.swiftinterface
+```
+
+grep で API 定義を直接確認できる。
+
+## Info.plist の使用目的文字列
+
+Enterprise API 用途では専用のキーが必要:
+
+| キー | 用途 |
+| :-- | :-- |
+| `NSMainCameraUsageDescription` | Main Camera Access |
+| `NSWorldSensingUsageDescription` | Enhanced World Sensing |
+
+権限文字列忘れは**無言でデータが来ない**ので、Step 1 と並行して必ず確認。

--- a/claude/.claude/skills/visionos-dev/references/immersive-space.md
+++ b/claude/.claude/skills/visionos-dev/references/immersive-space.md
@@ -1,0 +1,148 @@
+# ImmersiveSpace ライフサイクル / WorldAnchor 永続化
+
+Full Space の開閉、`scenePhase` での ARKitSession 停止/再開、WorldAnchor の永続化。
+
+## Scene ライフサイクル
+
+### 開く / 閉じる
+
+```swift
+@main
+struct MyApp: App {
+    @State var immersionStyle: ImmersionStyle = .mixed
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()   // ← 開閉ボタン
+        }
+
+        ImmersiveSpace(id: "MainSpace") {
+            ImmersiveView()
+        }
+        .immersionStyle(selection: $immersionStyle, in: .mixed, .progressive, .full)
+    }
+}
+
+struct ContentView: View {
+    @Environment(\.openImmersiveSpace)    private var openImmersiveSpace
+    @Environment(\.dismissImmersiveSpace) private var dismissImmersiveSpace
+    @State private var isImmersive = false
+
+    var body: some View {
+        Toggle("Immersive", isOn: $isImmersive)
+            .onChange(of: isImmersive) { _, newValue in
+                Task {
+                    if newValue {
+                        let result = await openImmersiveSpace(id: "MainSpace")
+                        switch result {
+                        case .opened:         break
+                        case .userCancelled:  isImmersive = false
+                        case .error:          isImmersive = false
+                        @unknown default:     isImmersive = false
+                        }
+                    } else {
+                        await dismissImmersiveSpace()
+                    }
+                }
+            }
+    }
+}
+```
+
+### immersionStyle の差
+
+| Style | 視界 | ユーザーがダイヤルで戻せるか |
+| :-- | :-- | :-- |
+| `.mixed` | 現実に 3D を重ねる (AR 風) | — |
+| `.progressive` | 現実とアプリが混ざる。ユーザーがダイヤルで調整可 | ✓ ダイヤル |
+| `.full` | 完全没入 (現実遮断) | — |
+
+`selection: $immersionStyle` で動的に切り替え可能。
+
+### OpenImmersiveSpaceAction.Result の分岐忘れ
+
+- `.opened`: 成功
+- `.userCancelled`: ユーザーが同意シートでキャンセル
+- `.error`: 失敗 (他のアプリが Full Space を占有中など)
+- `@unknown default:` — **Swift 6 で必須**
+
+## scenePhase 対応 — ARKitSession は OS が止める
+
+```swift
+struct ImmersiveView: View {
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var sensorManager = SensorManager()
+
+    var body: some View {
+        RealityView { content in ... }
+            .task {
+                try? await sensorManager.start()
+            }
+            .onChange(of: scenePhase) { _, newPhase in
+                Task {
+                    switch newPhase {
+                    case .background, .inactive:
+                        await sensorManager.stop()     // OS 側が止める前に明示停止
+                    case .active:
+                        try? await sensorManager.start()   // 再入時は再度 run()
+                    @unknown default:
+                        break
+                    }
+                }
+            }
+    }
+}
+```
+
+### 罠
+
+- **ARKitSession はバックグラウンドで OS から強制停止される**。復帰時に自動再開しない → `.active` で明示的に `run()` を再呼出
+- **`session.run()` は再起動扱い** — provider リストを再構築してから渡す
+- **ImmersiveSpace が閉じられた状態で `.active` トランジションが来る場合がある** — ImmersiveSpace の生存判定と scenePhase の判定を混ぜないこと (ImmersiveView 内の `.task` は ImmersiveSpace がアクティブな時だけ動く)
+- WindowGroup の View から ARKit を制御しようとしないこと — provider が Full Space で無いと anchor 来ない
+
+## WorldAnchor 永続化
+
+`WorldTrackingProvider` は anchor を OS 側に永続化する機能を持つ。ARKitSession を再起動しても位置が蘇る。
+
+### 追加
+
+```swift
+// ユーザーが置いた場所を永続化 (例: HandTracking で tap した位置)
+let anchor = WorldAnchor(originFromAnchorTransform: tapWorldTransform)
+try await worldTrackingProvider.addAnchor(anchor)
+```
+
+### 復元
+
+ARKitSession 再起動時、すでに永続化された anchor は `anchorUpdates` の `.added` イベントで流れてくる:
+
+```swift
+for await update in worldTrackingProvider.anchorUpdates {
+    switch update.event {
+    case .added:
+        // 再起動後、過去セッションで保存した anchor はここに来る
+        let anchor = update.anchor   // WorldAnchor
+        let id: UUID = anchor.id
+        let transform = anchor.originFromAnchorTransform
+        restoreVisualization(for: id, at: transform)
+    case .updated: /* 位置補正 */
+    case .removed: /* 削除通知 */
+    }
+}
+```
+
+### 削除
+
+```swift
+try await worldTrackingProvider.removeAnchor(anchor)
+// または id で
+try await worldTrackingProvider.removeAnchor(forID: uuid)
+```
+
+### ポイント
+
+- **UUID を自前で保存する必要はない** — WorldAnchor 自身が `id: UUID` を持ち、OS が永続化
+- 永続化の上限や TTL は非公開。実用上は 数百個 程度なら安定
+- Bundle ID / ユーザー単位で分離されている — 他アプリのアンカーは見えない
+- シミュレータでは永続化されない (そもそも WorldTracking 未対応)

--- a/claude/.claude/skills/visionos-dev/references/realitykit-ui.md
+++ b/claude/.claude/skills/visionos-dev/references/realitykit-ui.md
@@ -1,0 +1,202 @@
+# RealityKit / UI / Input
+
+`RealityView` の扱い、Entity ライフサイクル、ジェスチャ、Attachments、Reality Composer Pro 連携。
+
+## RealityView の基本パターン
+
+```swift
+import SwiftUI
+import RealityKit
+
+struct HandView: View {
+    @State var model = HandModel()
+
+    var body: some View {
+        RealityView { content in
+            // make: 初期エンティティを「事前割り当て」
+            let root = Entity()
+            for _ in 0..<27 {
+                let sphere = ModelEntity(
+                    mesh: .generateSphere(radius: 0.006),
+                    materials: [SimpleMaterial(color: .cyan, isMetallic: false)]
+                )
+                root.addChild(sphere)
+            }
+            content.add(root)
+            model.root = root
+        } update: { content in
+            // update: 毎フレーム transform だけ更新
+            // ↑ 子 entity を毎フレーム作り直さない (GC 圧迫)
+            for (i, joint) in model.joints.enumerated() {
+                model.root.children[i].transform = Transform(matrix: joint)
+            }
+        }
+        .upperLimbVisibility(.hidden)    // ← RealityView の閉じカッコの外!
+        .allowsHitTesting(false)         //   中に書くとビルドエラー
+    }
+}
+```
+
+### Entity 事前割り当ての鉄則
+
+- 毎フレーム `ModelEntity` を作ると GC で落ちる (数千 ops/sec)
+- 必要数を `make` クロージャで用意 → `update` で `transform` だけ書き換える
+- 動的に数が変わる場合は pool (プリアロケ済みリストから取り出し/戻す)
+
+## システムジェスチャ制御
+
+ハンドトラッキング中に OS の look+pinch UI を抑制したい:
+
+```swift
+RealityView { ... }
+    .upperLimbVisibility(.hidden)   // システムの上肢描画を非表示
+    .allowsHitTesting(false)        // look+pinch 入力自体を無効化
+```
+
+- `.upperLimbVisibility(_:)` 値: `.visible` / `.hidden` / `.automatic`
+- 両モディファイアとも **`RealityView` 本体の外側**に書かないとビルドエラー
+
+## Input — Gesture
+
+### エンティティをタップ可能にする
+
+**両方**のコンポーネントが必要。片方だけだと silent fail (エラーなしで反応しない)。
+
+```swift
+let cube = ModelEntity(mesh: .generateBox(size: 0.1))
+cube.components.set(InputTargetComponent())                        // ← 必須 1
+cube.components.set(CollisionComponent(shapes: [.generateBox(size: [0.1, 0.1, 0.1])]))   // ← 必須 2
+content.add(cube)
+```
+
+### SpatialTapGesture
+
+```swift
+RealityView { content in ... }
+    .gesture(
+        SpatialTapGesture()
+            .targetedToAnyEntity()       // RealityView 全体にアタッチ
+            .onEnded { value in
+                let entity = value.entity
+                let worldPos = value.convert(value.location3D, from: .local, to: .scene)
+                // 何かする
+            }
+    )
+```
+
+- `.targetedToAnyEntity()` で RealityView 内の `InputTargetComponent` 持ちエンティティ全てが対象
+- `.targetedToEntity(_:)` で特定エンティティに絞り込み
+
+### DragGesture (3D)
+
+```swift
+.gesture(
+    DragGesture()
+        .targetedToAnyEntity()
+        .onChanged { value in
+            let start = value.convert(value.startLocation3D, from: .local, to: .scene)
+            let now   = value.convert(value.location3D,      from: .local, to: .scene)
+            value.entity.position = now - start + initial
+        }
+)
+```
+
+### RotateGesture3D
+
+```swift
+.gesture(
+    RotateGesture3D()
+        .targetedToAnyEntity()
+        .onChanged { value in
+            value.entity.transform.rotation = .init(value.rotation.quaternion)
+        }
+)
+```
+
+### HoverEffectComponent — 視線ホバー強調
+
+```swift
+cube.components.set(HoverEffectComponent(.highlight(.init(color: .systemBlue))))
+// 他の Style: .spotlight / .lift
+```
+
+視線で見るだけで効果が発動する。**ジェスチャではない** (オプトインの視覚フィードバックのみ)。
+
+## Attachments — SwiftUI を 3D 空間に置く
+
+`RealityView` は 2-クロージャ形に拡張して SwiftUI ビューを attachment として埋め込める。
+
+```swift
+RealityView { content, attachments in
+    // make
+    if let label = attachments.entity(for: "info") {
+        label.position = [0, 0.2, 0]
+        content.add(label)
+    }
+} update: { content, attachments in
+    // update — SwiftUI の state 変化は attachment が自動再描画
+} attachments: {
+    Attachment(id: "info") {
+        VStack {
+            Text("Score: \(score)")
+            Button("Reset") { score = 0 }
+        }
+        .padding()
+        .glassBackgroundEffect()
+    }
+}
+```
+
+- `Attachment(id:)` の id は **文字列** (重複しないこと)
+- `attachments.entity(for: "info")` で `ViewAttachmentEntity` を取得 → **`content.add()` するのを忘れない** (忘れると表示されない)
+- SwiftUI の `@State` は attachments クロージャ内で参照できる。更新は自動反映
+- attachment 内のボタン/入力は通常の pinch で操作可能 (衝突コンポ不要)
+
+## Reality Composer Pro 連携
+
+Xcode 統合の 3D コンポーザー。`.usda` シーンを Swift Package bundle 経由で読み込む。
+
+```swift
+import RealityKit
+import RealityKitContent   // Xcode が自動生成する bundle
+
+let scene = try await Entity(named: "MyScene", in: realityKitContentBundle)
+content.add(scene)
+
+// 特定の Entity を取り出す
+if let handle = scene.findEntity(named: "Handle") {
+    handle.components.set(InputTargetComponent())
+}
+```
+
+### ShaderGraph マテリアルに値を流す
+
+Reality Composer Pro で作った `ShaderGraphMaterial` は Swift から parameter を書き換えられる。
+
+```swift
+var material = try await ShaderGraphMaterial(
+    named: "/Root/Materials/MyMat",
+    from: "MyScene",
+    in: realityKitContentBundle
+)
+try material.setParameter(name: "hue",       value: .float(0.5))
+try material.setParameter(name: "tintColor", value: .color(.red))
+
+entity.components[ModelComponent.self]?.materials = [material]
+```
+
+- parameter 名は Reality Composer Pro の Inspector で "Promoted Parameters" として公開したもの
+- 型ミスマッチは runtime error — `.swiftinterface` で `MaterialParameters.Value` の enum を確認
+
+## よく使う Component まとめ
+
+| Component | 用途 |
+| :-- | :-- |
+| `ModelComponent` | メッシュ + マテリアル |
+| `CollisionComponent` | 当たり判定 (ジェスチャにも必須) |
+| `InputTargetComponent` | タップ/ドラッグ対象マーク |
+| `HoverEffectComponent` | 視線ホバー強調 |
+| `PhysicsBodyComponent` | 物理シミュレーション |
+| `AnchoringComponent` | AR anchor 追従 |
+| `AudioLibraryComponent` | 音源アタッチ |
+| `Transform` (組み込み) | 位置/回転/スケール |


### PR DESCRIPTION
## Summary
- `evensdk-dev` を単一 234 行 SKILL.md から索引 64 行 + 3 references (sdk-usage / ui-constraints / ble-protocol) に分割
- `visionos-dev` の WIP (索引化 SKILL.md + 5 references) をコミット
- 両 skill の frontmatter `description` を API 名・定数・エラー名で強化し triggering accuracy を改善

## Why
`visionos-dev` は既に progressive disclosure パターン (索引 + references) になっていたが `evensdk-dev` は単一ファイルで非対称だった。`evensdk-dev` は SDK 日常使用 / UI ハマり / BLE リバース仕様が混在し、参照頻度の違う情報が同じコンテキストで読み込まれる状態。索引のみ常駐 → 必要な references だけ読む構成にしてコンテキスト消費を削減する。

## Impact
- 破壊的変更なし。両 skill 名・呼び出し面は維持
- `~/.claude/skills` symlink は `iri-dotfiles` を参照しているため、本 PR 単体ではランタイムの挙動は変わらない (dotfiles 運用側の切り替えが別途必要)
- `iri-dotfiles/claude/skills/visionos-dev` と本 PR の `visionos-dev` は `diff -rq` でゼロ diff

## Test
- `find claude/.claude/skills -type f` でファイル構成確認 (evensdk-dev 3 refs / visionos-dev 5 refs)
- `wc -l claude/.claude/skills/evensdk-dev/SKILL.md` → 64 行（索引サイズの目標 ~60 行内）
- `head -4` で両 SKILL.md の frontmatter が `name:` / `description:` 2 フィールド 1 行で構成されていることを目視
- `grep -n "references/" claude/.claude/skills/*/SKILL.md` で索引から参照する全 reference ファイルが実在
- Claude Code 上で `CLICK_EVENT` / `listObject` / `rebuildPageContainer` / `teleprompter` 等のキーワードで evensdk-dev が triggered されること、および Skill tool 明示呼び出しで索引が読まれることを確認

## Notes
- 最初のコミット `ff6d946` は `Co-Authored-By: Claude Opus 4.7` トレーラー入り、`7e90ff0` はフックで弾かれ除去。トレーラーを揃えたい場合は interactive rebase で先行コミットから落とす
- `skill-creator` プラグインによる機械評価 / ベンチは out of scope