### PR TITLE
[codex] custom skills を user scope に移動

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ macOS / Linux 向けの dotfiles。GNU Stow で `$HOME` に symlink を張って
 | `vim/` | vim 設定 (最小構成) |
 | `claude/` | Claude Code 設定 (`~/.claude/`) — global `CLAUDE.md` と skills も含む |
 | `codex/` | Codex 設定 (`~/.codex/`) — global `AGENTS.md` と Claude 由来 skills への導線 |
+| `agents/` | 共通 agent skills (`~/.agents/skills/`) — Codex の user-scope discovery 用 |
 | `setup/` | ライブラリ / starship / git 設定の bootstrap |
 
 ## セットアップ
@@ -23,14 +24,17 @@ cd ~/dotfiles
 `install.sh` は:
 
 1. `setup/install-libraries.sh` で OS 別に必要パッケージ (stow など) を導入
-2. `stow -t ~ zsh vim claude codex` で symlink を展開
-3. starship と git config を初期化
+2. `mkdir -p ~/.agents/skills` で Codex user-scope skill 用ディレクトリを用意
+3. `stow -t ~ zsh vim claude codex agents` で symlink を展開
+4. starship と git config を初期化
 
 ## AI エージェント設定
 
 - `codex/.codex/AGENTS.md` を共通ルールの正本として扱う
 - `claude/.claude/CLAUDE.md` は `AGENTS.md` への参照だけを持つ
-- `codex/.codex/skills/*` は Claude 側 skills を参照する導線で、実体の編集元は `claude/.claude/skills/*/SKILL.md`
+- `agents/.agents/skills/*` を Codex の user-scope skill 配置として扱う
+- `~/.agents` 自体は実ディレクトリにし、その配下の skill ディレクトリだけを symlink で管理する
+- skill 実体の編集元は `claude/.claude/skills/*/SKILL.md`
 
 ## 対応環境
 

--- a/agents/.agents/skills/evensdk-dev
+++ b/agents/.agents/skills/evensdk-dev
@@ -1,0 +1,1 @@
+../../../claude/.claude/skills/evensdk-dev

--- a/agents/.agents/skills/visionos-dev
+++ b/agents/.agents/skills/visionos-dev
@@ -1,0 +1,1 @@
+../../../claude/.claude/skills/visionos-dev

--- a/codex/.codex/skills/evensdk-dev/SKILL.md
+++ b/codex/.codex/skills/evensdk-dev/SKILL.md
@@ -1,1 +1,0 @@
-../../../../claude/.claude/skills/evensdk-dev/SKILL.md

--- a/codex/.codex/skills/visionos-dev/SKILL.md
+++ b/codex/.codex/skills/visionos-dev/SKILL.md
@@ -1,1 +1,0 @@
-../../../../claude/.claude/skills/visionos-dev/SKILL.md

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,8 @@ ROOT="$(cd "$(dirname "$0")" && pwd)"
 "$ROOT/setup/install-libraries.sh"
 
 cd "$ROOT"
-stow -v -t "$HOME" zsh vim claude codex
+mkdir -p "$HOME/.agents/skills"
+stow -v -t "$HOME" zsh vim claude codex agents
 
 "$ROOT/setup/install-starship.sh"
 "$ROOT/setup/setting-git-config.sh"


### PR DESCRIPTION
**Summary**
- Codex の custom skills 配置先を `~/.codex/skills` から `~/.agents/skills` に移動
- `agents/` 用の Stow パッケージを追加し、`install.sh` で `~/.agents/skills` を用意するよう変更
- 既存の Claude 側 skill ディレクトリを正本のまま使い、旧 `codex/.codex/skills/*` の導線を削除

**Why**
- `visionos-dev` と `evensdk-dev` が Codex CLI の available skills に表示されていなかった
- ローカル確認ではファイル自体は存在していたが、`~/.codex/skills` 配下では Codex に検出されなかった
- OpenAI の Codex ドキュメントでは user-scope の custom skills 配置先が `~/.agents/skills` とされており、以前の配置は正式な discovery 対象ではなかった

**Impact**
- Codex の custom skills は `~/.agents/skills` に配置される
- `~/.agents` 自体は実ディレクトリのままにし、その配下の skill ディレクトリだけを symlink 管理する必要がある
- Codex の共通ガイダンス入口は引き続き `codex/.codex/AGENTS.md`

**Test**
- `stow -R -v -t "$HOME" codex agents` を実行
- `find -L ~/.agents/skills -maxdepth 3 -print` で `visionos-dev/SKILL.md` と `evensdk-dev/SKILL.md` が解決できることを確認
- `codex debug prompt-input "list available skills" | rg "visionos-dev|evensdk-dev"` を実行
- custom skill 2 件が model-visible な skills 一覧に出ることを確認

**Notes**
- この PR は、以前の `~/.codex/skills` 配置を `~/.agents/skills` 配置へ置き換える follow-up
- 作業中に入った `claude/.claude/skills/evensdk-dev/SKILL.md` への一時的な追記は、この PR には含めていない
