### PR TITLE
[codex] Add smart agent workspace workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,27 @@ wt config shell install
 
 ## CLI ワークフロー
 
+- `ghq.root` は `~/Workspaces/src` に設定し、repository は `~/Workspaces/src/github.com/<owner>/<repo>` に揃える
 - `ghq get owner/repo` で repository を揃った場所に clone する
 - `g` で `ghq list -p` から `fzf` 選択して repository に移動する
 - `z` / `zi` で `zoxide` の履歴からよく使う場所に移動する
 - `gw` で Worktrunk の worktree picker / switch を使う
 - `gwc <branch>` で Worktrunk の worktree を作って移動する
+- `c` / `cx` は `~/Workspaces/src` 配下でのみ Codex を起動する
+- `ca` は `~/Workspaces/src` 配下でのみ現在の場所を Codex App で開く
+- `cl` は `~/Workspaces/src` 配下でのみ Claude Code を起動する
+- `ai <codex|claude|app|codex-app>` は `ghq list -p` から repository を選び、その場所で agent を起動する
+- `aip <codex|claude|app|codex-app>` は agent inbox repository で新規プロジェクトの企画・調査を始める
 
 ## AI エージェント設定
 
 - `codex/.codex/AGENTS.md` を共通ルールの正本として扱う
 - `claude/.claude/CLAUDE.md` は `AGENTS.md` への参照だけを持つ
+- agent 別の `~/Workspaces/ws_codex` / `ws_claude` は作らず、`~/Workspaces/src` 配下の通常 repository / worktree だけで作業する
+- 新規プロジェクトの企画・調査は `~/Workspaces/src/github.com/ijiwarunahello/workspace-inbox` から始める
+- trusted workspace root は `WORKSPACES_SRC=/path/to/src` で上書きできる
+- agent inbox repository は `AGENT_INBOX_REPO=/path/to/repo` で上書きできるが、agent 起動時は trusted workspace root 配下に置く
+- 実装に進む段階では対象 project repository / worktree に移動してから agent を起動する
 - `agents/.agents/skills/*` を Codex の user-scope skill 配置として扱う
 - `~/.agents` 自体は実ディレクトリにし、その配下の skill ディレクトリだけを symlink で管理する
 - Even Hub / G2 開発支援は `agents/.agents/skills/evenhub-*` の user-scope skills を使う

--- a/codex/.codex/AGENTS.md
+++ b/codex/.codex/AGENTS.md
@@ -41,3 +41,12 @@ All PR descriptions must use these five sections, in this order, and stay concis
 
 Keep each section short. Omit filler. Do not add extra sections.
 Write PR descriptions in Japanese unless the user explicitly asks for another language.
+
+## Agent Workspace Operation
+
+- Do not create or rely on agent-specific workspaces such as `~/Workspaces/ws_codex` or `~/Workspaces/ws_claude`.
+- Treat `~/Workspaces/src` as the trusted workspace root.
+- Do normal project work inside `~/Workspaces/src/github.com/<owner>/<repo>` or a worktree managed from that repository.
+- Start new project planning and initial research from the inbox repository at `~/Workspaces/src/github.com/ijiwarunahello/workspace-inbox`, unless `AGENT_INBOX_REPO` points to another inbox repository under the trusted workspace root.
+- When planning turns into implementation, move into the target project repository or worktree before editing files or running project commands.
+- If work must start outside `~/Workspaces/src`, ask the user before proceeding.

--- a/zsh/.zsh/.zshrc
+++ b/zsh/.zsh/.zshrc
@@ -27,13 +27,126 @@ _dotfiles_require() {
   fi
 }
 
-g() {
+_dotfiles_workspace_root() {
+  printf '%s\n' "${WORKSPACES_SRC:-$HOME/Workspaces/src}"
+}
+
+_dotfiles_agent_inbox_repo() {
+  printf '%s\n' "${AGENT_INBOX_REPO:-$(_dotfiles_workspace_root)/github.com/ijiwarunahello/workspace-inbox}"
+}
+
+_dotfiles_agent_cwd_allowed() {
+  local root cwd
+  root="$(_dotfiles_workspace_root)"
+  root="${root:A}"
+  cwd="${PWD:A}"
+
+  case "$cwd" in
+    "$root"|"$root"/*) return 0 ;;
+  esac
+
+  printf '%s\n' "agent cwd is outside trusted workspace root: $cwd" >&2
+  printf '%s\n' "trusted workspace root: $root" >&2
+  return 1
+}
+
+_dotfiles_run_agent() {
+  if [ "$#" -eq 0 ]; then
+    printf '%s\n' "usage: _dotfiles_run_agent <codex|claude|app|codex-app> [args...]" >&2
+    return 2
+  fi
+
+  local agent
+  agent="$1"
+  shift
+
+  case "$agent" in
+    codex|claude|app|codex-app) ;;
+    *)
+      printf '%s\n' "usage: _dotfiles_run_agent <codex|claude|app|codex-app> [args...]" >&2
+      return 2
+      ;;
+  esac
+
+  case "$agent" in
+    app|codex-app)
+      _dotfiles_require codex || return
+      ;;
+    *)
+      _dotfiles_require "$agent" || return
+      ;;
+  esac
+  _dotfiles_agent_cwd_allowed || return
+
+  case "$agent" in
+    app|codex-app) command codex app "$@" ;;
+    *) command "$agent" "$@" ;;
+  esac
+}
+
+_dotfiles_pick_repo() {
   _dotfiles_require ghq || return
   _dotfiles_require fzf || return
 
   local repo
   repo="$(ghq list -p | fzf --prompt='repo> ')" || return
+  [ -n "$repo" ] || return 1
+  printf '%s\n' "$repo"
+}
+
+g() {
+  local repo
+  repo="$(_dotfiles_pick_repo)" || return
   [ -n "$repo" ] && cd "$repo"
+}
+
+c() {
+  _dotfiles_run_agent codex "$@"
+}
+
+cx() {
+  _dotfiles_run_agent codex "$@"
+}
+
+ca() {
+  _dotfiles_run_agent app "$@"
+}
+
+cl() {
+  _dotfiles_run_agent claude "$@"
+}
+
+ai() {
+  if [ "$#" -eq 0 ]; then
+    printf '%s\n' "usage: ai <codex|claude|app|codex-app> [args...]" >&2
+    return 2
+  fi
+
+  local agent repo
+  agent="$1"
+  shift
+  repo="$(_dotfiles_pick_repo)" || return
+  cd "$repo" && _dotfiles_run_agent "$agent" "$@"
+}
+
+aip() {
+  if [ "$#" -eq 0 ]; then
+    printf '%s\n' "usage: aip <codex|claude|app|codex-app> [args...]" >&2
+    return 2
+  fi
+
+  local agent repo
+  agent="$1"
+  shift
+  repo="$(_dotfiles_agent_inbox_repo)"
+
+  if [ ! -d "$repo" ]; then
+    printf '%s\n' "agent inbox repo does not exist: $repo" >&2
+    printf '%s\n' "create it under ~/Workspaces/src or set AGENT_INBOX_REPO." >&2
+    return 1
+  fi
+
+  cd "$repo" && _dotfiles_run_agent "$agent" "$@"
 }
 
 gw() {


### PR DESCRIPTION
## Summary

- agent 起動用の zsh wrapper を追加し、`~/Workspaces/src` 配下でのみ Codex / Claude Code を起動できるようにした
- 新規企画用の agent inbox repository と、repo picker 経由の agent 起動フローを README に追記した
- `AGENTS.md` に agent workspace 運用ルールを追加した

## Why

agent 別の `ws_codex` / `ws_claude` 運用を廃止し、通常 repository / worktree 配下で安全に作業を始められるようにするため。

## Impact

- `c` / `cx` / `cl` / `ai` / `aip` が zsh で利用可能になる
- `WORKSPACES_SRC` と `AGENT_INBOX_REPO` で trusted root / inbox repo を上書きできる
- agent は `~/Workspaces/src` 外で作業開始が必要な場合、ユーザー確認を求めるようになる

## Test

- `zsh -n zsh/.zsh/.zshrc`
- `git diff --check -- zsh/.zsh/.zshrc codex/.codex/AGENTS.md README.md`
- 非対話 shell で `~/Workspaces/src` 配下の許可、`/tmp` の拒否、`ai` / `aip` の usage / missing inbox handling を確認
- 壊れていた zsh symlink を現在の repo に張り直し、login shell で starship と wrapper 関数が読み込まれることを確認

## Notes

- default の inbox repo `~/Workspaces/src/github.com/ijiwarunahello/workspace-inbox` は別途作成が必要
- ローカルの `gh` token は invalid だったため、PR 作成は GitHub connector を使用した